### PR TITLE
Add codebase_version.html to webserver

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,8 @@ services:
     build:
       context: .
       dockerfile: webserver/Dockerfile
+      args:
+        codebaseversion: ${CODEBASE_VERSION:-When this image was built with docker-compose, <pre>CODEBASE_VERSION</pre> environment variable was not present.}
     ports:
       - "8080:80"
       - "22002:22"

--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -157,6 +157,9 @@ ENV WG_PROTOCOL http
 ENV WG_SECRET_KEY 04f44118ad1899762bc60ed90d778aa72f92e9dc0d298c8f327755e503ceb84a
 ENV WG_UPGRADE_KEY 1ce9e4e2a0a3bf63
 
+ARG codebaseversion=When this image was built with Docker, <pre>codebaseversion</pre> Docker arg was not specified.
+RUN echo "<html><body>${codebaseversion}</body></html>" > /rw/codebase_version.html
+
 CMD sh /root/system_start.sh
 
 # To explore the system to see how things have been set up, following building:


### PR DESCRIPTION
This PR adds `codebase_version.html` to the root of the webserver and populates it with information regarding how the webserver image was built when deploy_tool.py is used to perform actions on the site.  Implements #8.  See an example of `codebase_version.html` on [the staging server](https://dev.ropewiki.com/codebase_version.html).