### PR TITLE
Add second server name for www prefix

### DIFF
--- a/deploy_tool.py
+++ b/deploy_tool.py
@@ -377,10 +377,10 @@ def add_cert_cronjob(site_config: SiteConfig, options: List[str]):
 
 @deploy_command
 def redeploy(site_config: SiteConfig, options: List[str]):
-  redeploy_targets = {'webserver', 'db'}
-  if options[0] not in redeploy_targets:
+  redeploy_targets = {'webserver', 'db', 'reverse-proxy'}
+  if not options or options[0] not in redeploy_targets:
     sys.exit('Expected: redeploy {{{}}}'.format('|'.join(redeploy_targets)))
-  log('Redeploying webserver by rebuilding, taking down, then restarting service')
+  log(f'Redeploying {options[0]} by rebuilding, taking down, then restarting service')
   if options[0] == 'webserver':
     run_docker_compose('build {}'.format(site_config.webserver_service), site_config)
     run_docker_compose('rm -f -s -v {}'.format(site_config.webserver_service), site_config)
@@ -388,6 +388,10 @@ def redeploy(site_config: SiteConfig, options: List[str]):
   elif options[0] == 'db':
     run_docker_compose('build {}'.format(site_config.db_service), site_config)
     run_docker_compose('rm -f -s {}'.format(site_config.db_service), site_config)
+    start_site(site_config, [])
+  elif options[0] == 'reverse-proxy':
+    run_docker_compose('build {}'.format(site_config.reverse_proxy_service), site_config)
+    run_docker_compose('rm -f -s {}'.format(site_config.reverse_proxy_service), site_config)
     start_site(site_config, [])
 
 @deploy_command

--- a/reverse_proxy/services.conf
+++ b/reverse_proxy/services.conf
@@ -33,7 +33,7 @@ server {
 }
 
 server {
-  server_name www.{{WG_HOSTNAME}
+  server_name www.{{WG_HOSTNAME};
   listen 80;
   return 301 https://{{WG_HOSTNAME}}$request_uri;
 }

--- a/reverse_proxy/services.conf
+++ b/reverse_proxy/services.conf
@@ -33,7 +33,7 @@ server {
 }
 
 server {
-  server_name www.{{WG_HOSTNAME};
+  server_name www.{{WG_HOSTNAME}};
   listen 80;
   return 301 https://{{WG_HOSTNAME}}$request_uri;
 }

--- a/reverse_proxy/services.conf
+++ b/reverse_proxy/services.conf
@@ -31,3 +31,9 @@ server {
   # This line logs accesses to this service
   access_log /var/log/nginx/access.log main;
 }
+
+server {
+  server_name www.{{WG_HOSTNAME}
+  listen 80;
+  return 301 https://{{WG_HOSTNAME}}$request_uri;
+}


### PR DESCRIPTION
This PR adds a 301 redirect from a `www.`-prefixed hostname to the plain hostname (`WG_HOSTNAME`).  This is intended to cause www.ropewiki.com to behave like ropewiki.com, but I have not tested it as my dev server setup uses a different reverse proxy.