### PR TITLE
Update ShellLocale to an available locale

### DIFF
--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -75,7 +75,7 @@ $wgUseInstantCommons  = false;
 ## If you use ImageMagick (or any other shell command) on a
 ## Linux server, this will need to be set to the name of an
 ## available UTF-8 locale
-$wgShellLocale = "en_US.utf8";
+$wgShellLocale = "C.UTF-8";
 
 ## If you want to use image uploads under safe mode,
 ## create the directories images/archive, images/thumb and


### PR DESCRIPTION
en_US.utf8 is the current setting and it is not installed on the server, however C.UTF-8 is installed and it solves the problem of creating thumbnails with accented characters.

See this link for more info:
https://www.mediawiki.org/wiki/Manual:Common_errors_and_symptoms#Image_Thumbnails_not_working_and/or_appearing:~:text=When%20the%20path%20is%20missing%20non%2DASCII%20characters