### PR TITLE
Add hostnames to containers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
   # The RopeWiki MySQL database; see instructions in README.md to build the image
   ropewiki_db:
     image: ropewiki/database
+    hostname: ropewiki_db
     build:
       context: .
       dockerfile: database/Dockerfile
@@ -32,6 +33,7 @@ services:
   # The main RopeWiki server running MediaWiki; see instructions in README.md to build the image
   ropewiki_webserver:
     image: ropewiki/webserver
+    hostname: ropewiki_webserver
     build:
       context: .
       dockerfile: webserver/Dockerfile
@@ -55,6 +57,7 @@ services:
   # The reverse proxy that directs traffic to the appropriate places; see instructions in README.md to build the image
   ropewiki_reverse_proxy:
     image: ropewiki/reverse_proxy
+    hostname: ropewiki_reverse_proxy
     build:
       context: .
       dockerfile: reverse_proxy/Dockerfile


### PR DESCRIPTION
Just a very minor quality-of-life fix.

Noticed the containers don't set their hostname, so when you ssh into them you don't get a nice prompt confirming which one you've accessed.

e.g.
```
[...]
Last login: Thu May 11 07:13:07 2023 from 75.172.120.71
backupreader@8ce4ef5ab64f:~
```

Now it should appear:
```
backupreader@ropewiki_db:~
```