### PR TITLE
Fix DB Backups! 🤩

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -5,7 +5,7 @@
 FROM mysql:5.7-debian
 
 # Install necessary tools
-RUN apt-get update && apt-get -y install cron openssh-server
+RUN apt-get update && apt-get -y install cron openssh-server less rsync nano
 
 # Create a user named `backupreader` for reading database backups
 RUN useradd --create-home --shell /bin/bash backupreader

--- a/database/backup.cron
+++ b/database/backup.cron
@@ -1,1 +1,1 @@
-0 10 * * * /bin/sh /home/root/backup_mysql.sh > /dev/null 2>&1
+0 10 * * * bash /home/root/backup_mysql.sh >> /home/backupreader/backups/backup.log 2>&1

--- a/database/scripts/system_start.sh
+++ b/database/scripts/system_start.sh
@@ -20,6 +20,7 @@ else
 
   # Enable SSH
   service ssh start
+  service cron start
 
   touch /ropewiki_setup_complete
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       - RW_ROOT_DB_PASSWORD=${RW_ROOT_DB_PASSWORD:-}
     volumes:
       - ropewiki_database_storage:/var/lib/mysql
-      - ${SQL_BACKUP_FOLDER:?SQL_BACKUP_FOLDER environment variable must be set}:/root/backup
+      - ${SQL_BACKUP_FOLDER:?SQL_BACKUP_FOLDER environment variable must be set}:/home/backupreader/backups
 #    restart: always
 
   # The main RopeWiki server running MediaWiki; see instructions in README.md to build the image

--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get install -y --no-install-recommends software-properties-common && \
     apt-get install -y --no-install-recommends php5.6 php5.6-fpm php5.6-cli php5.6-mysql php5.6-imagick php5.6-xml php5.6-mbstring
 
 # Install various tools
-RUN apt-get install -y --no-install-recommends wget unzip git nano sed curl imagemagick openssh-server
+RUN apt-get install -y --no-install-recommends wget unzip git nano sed curl imagemagick openssh-server less rsync
 
 # Install composer
 # https://stackoverflow.com/a/51446468/651139


### PR DESCRIPTION
 - Backups actually run automatically (starts cron)!
 - Fixes path to SQL_BACKUP_FOLDER (i.e. backups now persist outside the container).
 - Adds logging (size, time, etc) to `backup.log`.
 - Touches `last_success` file for future monitoring.
 - Improves timestamp in backup filename (`2023-05-13-181803`) so that there can be more than one backup a day.
 - Add a killswitch to stop backup (`/do_not_backup_db`), e.g. during development 
 - Install `rsync` and `less` in the containers.

 
 Example log entry (of minimal database):
 ```
 === Sun May 14 06:21:01 UTC 2023 ===
Starting backup to /home/backupreader/backups/all-backup-2023-05-14-062101.sql.gz
mysqldump: [Warning] Using a password on the command line interface can be insecure.

real    0m0.222s
user    0m0.207s
sys     0m0.015s
-rw-r--r-- 1 root root 798K May 14 06:21 /home/backupreader/backups/all-backup-2023-05-14-062101.sql.gz
===============
 ```