### PR TITLE
SMTP mail relay & mediawiki config 📧2️

### DIFF
--- a/deploy_tool.py
+++ b/deploy_tool.py
@@ -33,6 +33,7 @@ class SiteConfig(object):
   reverse_proxy_service = 'ropewiki_reverse_proxy'
   webserver_service = 'ropewiki_webserver'
   backup_manager_service = 'ropewiki_backup_manager'
+  mailserver_service = 'ropewiki_mailserver'
 
   _db_password: str
   _root_db_password: str
@@ -409,7 +410,7 @@ def add_cert_cronjob(site_config: SiteConfig, options: List[str]):
 
 @deploy_command
 def redeploy(site_config: SiteConfig, options: List[str]):
-  redeploy_targets = {'webserver', 'db', 'reverse_proxy', 'backup_manager'}
+  redeploy_targets = {'webserver', 'db', 'reverse_proxy', 'backup_manager', 'mailserver'}
   if not options or options[0] not in redeploy_targets:
     sys.exit('Expected: redeploy {{{}}}'.format('|'.join(redeploy_targets)))
   log(f'Redeploying {options[0]} by rebuilding, taking down, then restarting service')
@@ -428,6 +429,10 @@ def redeploy(site_config: SiteConfig, options: List[str]):
   elif options[0] == 'backup_manager':
     run_docker_compose('build {}'.format(site_config.backup_manager_service), site_config)
     run_docker_compose('rm -f -s {}'.format(site_config.backup_manager_service), site_config)
+    start_site(site_config, [])
+  elif options[0] == 'mailserver':
+    run_docker_compose('build {}'.format(site_config.mailserver_service), site_config)
+    run_docker_compose('rm -f -s {}'.format(site_config.mailserver_service), site_config)
     start_site(site_config, [])
 
 @deploy_command

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -93,6 +93,27 @@ services:
       - ${IMAGES_FOLDER:?IMAGES_FOLDER environment variable must be set}:/home/backupreader/images:ro
 #    restart: always
 
+  ropewiki_mailserver:
+    image: ropewiki/mailserver
+    hostname: ropewiki_mailserver
+    build:
+      context: .
+      dockerfile: mailserver/Dockerfile
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+    environment:
+      - RELAY_HOST_NAME=${WG_HOSTNAME:-localhost}
+      - EXT_RELAY_HOST=${RW_SMTP_HOST:-smtp.gmail.com}
+      - EXT_RELAY_PORT=${RW_SMTP_PORT:-587}
+      - SMTP_LOGIN=${RW_SMTP_USERNAME}
+      - SMTP_PASSWORD=${RW_SMTP_PASSWORD}
+      - USE_TLS=yes  # Use TLS to talk upstream to the internet
+      - TLS_VERIFY=may
+      - INBOUND_TLS=no  # Don't require local clients to use TLS
+      - ACCEPTED_NETWORKS=172.16.0.0/12  # Only accept connections from docker's internal network
+
 volumes:
   ropewiki_database_storage:
     name: ropewiki_database_storage

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -107,8 +107,8 @@ services:
       - RELAY_HOST_NAME=${WG_HOSTNAME:-localhost}
       - EXT_RELAY_HOST=${RW_SMTP_HOST:-smtp.gmail.com}
       - EXT_RELAY_PORT=${RW_SMTP_PORT:-587}
-      - SMTP_LOGIN=${RW_SMTP_USERNAME}
-      - SMTP_PASSWORD=${RW_SMTP_PASSWORD}
+      - SMTP_LOGIN="${RW_SMTP_USERNAME:?RW_SMTP_USERNAME must be non-empty}"
+      - SMTP_PASSWORD="${RW_SMTP_PASSWORD:?RW_SMTP_PASSWORD must be non-empty}"
       - USE_TLS=yes  # Use TLS to talk upstream to the internet
       - TLS_VERIFY=may
       - INBOUND_TLS=no  # Don't require local clients to use TLS

--- a/mailserver/Dockerfile
+++ b/mailserver/Dockerfile
@@ -1,0 +1,1 @@
+FROM alterrebe/postfix-relay:latest

--- a/mailserver/README.md
+++ b/mailserver/README.md
@@ -1,0 +1,44 @@
+This container runs a postfix server as mail relay.
+
+It doesn't really need its own custom docker image, as the upstream image is fully controlled with environment variables. However to stay in keeping with the other containers, it's rebuilt as `ropewiki/mailserver`.
+
+Clients running inside the docker network can send mail to `ropewiki_mailserver` on port 25 to have mail relayed for them.
+
+### Deployment
+
+By default it routes mail via gmail's smtp relay, and requires providing two environment variables:
+
+```
+    $RW_SMTP_USERNAME
+    $RW_SMTP_PASSWORD
+```
+
+These can be your own personal credentials for testing ([setup guide](https://www.gmass.co/blog/gmail-smtp/)), or the real credentials for `ropewiki@gmail.com`.
+
+If you want to relay mail via a different provider (e.g. your hosting provider requires you to use theirs), you can additionally set:
+
+```
+    $RW_SMTP_HOST
+    $RW_SMTP_PORT
+```
+
+### Testing & Investigating
+
+Useful commands inside the mailserver container:
+- `tail -f /var/log/mail.log` shows delivery logs.
+- `mailq` shows any pending deliveries.
+- `apk add mailx && echo "Test msg from $(hostname)" | mail -s "Test msg" $YOUREMAILADDRESS` send a test message.
+
+From outside the container:
+ - Any website activity which triggers an email, such as a password reset.
+
+A successful delivery from the webserver should look like this:
+```
+2023-05-24T00:40:28.770384+00:00 ropewiki_mailserver postfix/smtpd[123]: connect from ropewiki_webserver-1_default[172.19.0.5]
+2023-05-24T00:40:28.779616+00:00 ropewiki_mailserver postfix/smtpd[123]: BE4F22EF281: client=ropewiki_webserver-1_default[172.19.0.5]
+2023-05-24T00:40:28.827234+00:00 ropewiki_mailserver postfix/cleanup[126]: BE4F22EF281: message-id=<ropewiki.646d5cfcb9eed1.12442089@ropewiki>
+2023-05-24T00:40:28.837384+00:00 ropewiki_mailserver postfix/qmgr[91]: BE4F22EF281: from=<admin@ropewiki.com>, size=1067, nrcpt=1 (queue active)
+2023-05-24T00:40:28.837449+00:00 ropewiki_mailserver postfix/smtpd[123]: disconnect from ropewiki_webserver-1_default[172.19.0.5] ehlo=1 mail=1 rcpt=1 data=1 quit=1 commands=5
+2023-05-24T00:40:29.679726+00:00 ropewiki_mailserver postfix/smtp[127]: BE4F22EF281: to=<admin@ropewiki.com>, relay=smtp.gmail.com[74.125.195.108]:587, delay=0.9, delays=0.06/0.03/0.25/0.56, dsn=2.0.0, status=sent (250 2.0.0 OK  1684888829 u26-20020aa7839a000000b006259e883ee9sm217323pfm.189 - gsmtp)
+2023-05-24T00:40:29.680458+00:00 ropewiki_mailserver postfix/qmgr[91]: BE4F22EF281: removed
+```

--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -26,7 +26,18 @@ RUN apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository ppa:ondrej/php && \
     apt-get update && \
     printf '#!/bin/sh\nexit 0' > /usr/sbin/policy-rc.d && \
-    apt-get install -y --no-install-recommends php5.6 php5.6-fpm php5.6-cli php5.6-mysql php5.6-imagick php5.6-xml php5.6-mbstring
+    apt-get install -y --no-install-recommends \
+        php5.6 \
+        php5.6-fpm \
+        php5.6-cli \
+        php5.6-mysql \
+        php5.6-imagick \
+        php5.6-xml \
+        php5.6-mbstring \
+        php-pear
+
+# Install the PEAR mail module and its deps.
+RUN pear install --alldeps mail
 
 # Install various tools
 RUN apt-get install -y --no-install-recommends wget unzip git nano sed curl imagemagick less

--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -290,3 +290,11 @@ $wgScriptExtension  = ".php";
 $wgSearchType = "SphinxMWSearch";
 require_once "$IP/extensions/SphinxSearch/SphinxSearch.php";
 $wgEnableSphinxPrefixSearch = true;
+
+# With this config we don't need to install & configure sendmail inside
+# the webserver container (which php's mail() will try and use by default).
+$wgSMTP = array(
+    'host' => 'ropewiki_mailserver',
+    'port' => 25,
+    'auth' => false
+);


### PR DESCRIPTION
While https://github.com/RopeWiki/app/pull/26 technically worked - the realities of the internet in 2023 mean many hosting companies simply do not want you hosting your own mailserver. So this is a do-over using gmail's smtp relay instead.

Lots of details in the readme.

I've tested it with my own credentials (which I can share if people want to test with), but in production it will need to be provided with ropewiki@gmail.com's smtp password (link to a setup guide in the readme).