### PR TITLE
Use X-Forwarded-For header to transmit true remote IP address

### DIFF
--- a/reverse_proxy/services.conf
+++ b/reverse_proxy/services.conf
@@ -22,10 +22,12 @@ server {
 
   location / {
     proxy_pass http://ropewiki_local/;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
   location /luca {
     proxy_pass http://luca_remote;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
   # This line logs accesses to this service

--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -298,3 +298,7 @@ $wgSMTP = array(
     'port' => 25,
     'auth' => false
 );
+
+# Use the X-Forwarded-For IP address as the remote address
+# See: https://www.mediawiki.org/wiki/Topic:Ra22sndx88fnifz1
+$_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_X_FORWARDED_FOR'];


### PR DESCRIPTION
This PR resolves #33 by having the reverse proxy transmit the true remote address in an X-Forwarded-For header, and then adjusting the webserver configuration to use that IP address as the remote IP address.

This PR was tested by deploying an empty site instance (via restore_schema) on a GCP VM and verifying that the IP address displayed on the home page was the correct external IP address.