### PR TITLE
Ask for confirmation before restoring db

### DIFF
--- a/deploy_tool.py
+++ b/deploy_tool.py
@@ -344,6 +344,11 @@ def create_db(site_config: SiteConfig, options: List[str]):
 def load_sql(site_config: SiteConfig, backup_path: str):
   cat_tool = 'type' if platform.system() == 'Windows' else 'cat'
 
+  response = input(f"Restore {backup_path}? (y/n): ").lower()
+  if response not in ("y", "yes"):
+    log('Aborting restore')
+    sys.exit(1)
+
   log('Ensuring backup manager is available...')
   run_docker_compose('up -d {backup_manager_service}'.format(backup_manager_service=site_config.backup_manager_service), site_config)
 


### PR DESCRIPTION
This adds a safety check when restoring the database.

I've done Ctrl+R to rerun a deploy_tool command and accidentally ran restore_db, which immediately wipes out the current db without any chance to abort.

Confirmed it works for both `restore_empty_db` and `restore_db`.

```
./deploy_tool.py ak restore_empty_db
Restore /mnt/data/containers/ropewiki/database/empty_schema.sql? (y/n): n
2023-06-07T19:54:31.040363 Aborting restore
```