### PR TITLE
Add ReplaceText extension

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -97,6 +97,7 @@ RUN cd /rw/extensions && git clone https://gitlab.com/troyengel/Preloader && cd 
 RUN cd /rw/extensions && git clone https://github.com/RopeWiki/SemanticForms && cd SemanticForms && git checkout 9169c63
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-skins-Vector Vector && cd Vector && git checkout fad72e2
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-MultimediaViewer.git MultimediaViewer && cd MultimediaViewer && git checkout REL1_24
+RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-ReplaceText ReplaceText && cd ReplaceText && git checkout REL1_24
 
 # Present in main site but not here:
 # APC

--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -200,6 +200,7 @@ require_once "$IP/extensions/MagicNoCache/MagicNoCache.php";
 require_once "$IP/extensions/Preloader/Preloader.php";
 $wgPreloaderSource[NS_CONDITIONS] = 'Template:ConditionsBoilerplate';
 require_once "$IP/extensions/CheckUser/CheckUser.php";
+require_once "$IP/extensions/ReplaceText/ReplaceText.php";
 
 # Editor tools
 require_once "$IP/extensions/WikiEditor/WikiEditor.php";


### PR DESCRIPTION
This extension is included by default in MediaWiki versions 1.31 and above. It allows sitewide text replacement for bureaucrat level users and above.