### PR TITLE
Switch backups to use zstd rather than gzip

### DIFF
--- a/backup_manager/Dockerfile
+++ b/backup_manager/Dockerfile
@@ -6,7 +6,13 @@
 FROM mysql:5.7-debian
 
 # Install necessary tools
-RUN apt-get update && apt-get -y install cron openssh-server less rsync nano
+RUN apt-get update && apt-get -y install \
+    cron \
+    less \
+    nano \
+    openssh-server \
+    rsync \
+    zstd
 
 # Create a user named `backupreader` for reading database backups
 RUN useradd --create-home --shell /bin/bash backupreader

--- a/backup_manager/scripts/backup_mysql.sh
+++ b/backup_manager/scripts/backup_mysql.sh
@@ -11,7 +11,7 @@ fi
 
 BASE_PATH="/home/backupreader/backups"
 DATE=$(date +'%Y-%m-%d-%H%M%S')  # e.g. 2023-05-13-181803
-BACKUP="${BASE_PATH}/all-backup-${DATE}.sql.gz"
+BACKUP="${BASE_PATH}/all-backup-${DATE}.sql.zst"
 
 echo "Starting backup to $BACKUP"
 
@@ -20,7 +20,7 @@ time mysqldump --host ropewiki_db \
           --add-drop-database \
           --single-transaction \
           --user=root --password="{{RW_ROOT_DB_PASSWORD}}" \
-          | gzip > ${BACKUP}
+          | zstd -10 > ${BACKUP}
 
 # Owner: rw-, Group: r--, Others: r--
 chmod 644 ${BACKUP}


### PR DESCRIPTION
In summary this is a super easy way of making our backups a lot smaller.

More details are explained here: https://github.com/RopeWiki/app/issues/31