### PR TITLE
Use docker compose v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,9 @@ the `PATH` (`python3 --version` to verify). Ignore all `apt` commands and instea
 
 1. Update packages (`sudo apt-get update`)
 1. [Install docker](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository)
-1. [Install legacy/v1 docker-compose](https://docs.docker.com/compose/install/#install-compose-on-linux-systems) with `sudo apt install docker-compose`
     1. Fix [this issue](https://github.com/docker/compose/issues/6931)
-       with `sudo apt update && apt install rng-tools`
-    1. Verify installation with `docker-compose --version`; result should be 1.29.2 or similar, not 2.x.x
+       with `sudo apt update && apt install rng-tools` (note: this may no longer be necessary with docker compose v2)
+    1. Verify installation with `docker compose version`; result should be 2.x.x
 1. Install git (`sudo apt-get install git`)
 1. Clone this repository into an appropriate folder (perhaps `/rw`)
 
@@ -118,7 +117,7 @@ synchronize the full content of the `images` folder to back them up.
 This should be performed by a cron job, but in the event of needing to do it manually,
 run `python3 deploy_tool.py <SITE_NAME> renew_certs`
 
-### Arbitrary docker-compose commands
+### Arbitrary docker compose commands
 
 The docker-compose.yaml configuration requires a number of environment variables to be set before it can be used. To
 avoid the need to set these variables yourself (apart from WG_DB_PASSWORD and RW_ROOT_DB_PASSWORD), use

--- a/deploy_tool.py
+++ b/deploy_tool.py
@@ -40,7 +40,7 @@ class SiteConfig(object):
 
   @property
   def db_container(self) -> str:
-    return '{}_{}_1'.format(self.name, self.db_service)
+    return '{}-{}-1'.format(self.name, self.db_service)
 
   @property
   def db_hostname(self) -> str:
@@ -48,7 +48,7 @@ class SiteConfig(object):
 
   @property
   def backup_manager_container(self) -> str:
-    return '{}_{}_1'.format(self.name, self.backup_manager_service)
+    return '{}-{}-1'.format(self.name, self.backup_manager_service)
 
   @property
   def db_password(self) -> str:
@@ -173,7 +173,7 @@ def get_codebase_version() -> str:
 
 def make_docker_compose_script(cmd: str, site_config: SiteConfig) -> Tuple[str, str]:
   make_var_cmd = 'set ' if platform.system() == 'Windows' else 'export '
-  docker_compose_command = 'docker-compose -p {name} {cmd}'.format(name=site_config.name, cmd=cmd)
+  docker_compose_command = 'docker compose -p {name} {cmd}'.format(name=site_config.name, cmd=cmd)
   variable_declarations = '\n'.join([
     '{cmd}RW_ROOT_DB_PASSWORD={root_db_password}',
     '{cmd}MYSQL_ROOT_PASSWORD={root_db_password}',

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,10 @@
-# This docker-compose file will bring up a production system.
-# As per README.md, direct docker-compose commands are not
+# This docker compose file will bring up a production system.
+# As per README.md, direct docker compose commands are not
 # recommended because that requires many environment variables
 # to be set.  Instead, the use of deploy_tool.py is recommended
 # as per README.md.
 
-# Before any other docker-compose commands above are executed,
+# Before any other docker compose commands above are executed,
 # the necessary images must be built according to the instructions
 # in README.md.
 #   python3 deploy_tool.py <SITE_NAME> dc build
@@ -35,7 +35,7 @@ services:
       context: .
       dockerfile: webserver/Dockerfile
       args:
-        codebaseversion: ${CODEBASE_VERSION:-When this image was built with docker-compose, <pre>CODEBASE_VERSION</pre> environment variable was not present.}
+        codebaseversion: ${CODEBASE_VERSION:-When this image was built with docker compose, <pre>CODEBASE_VERSION</pre> environment variable was not present.}
     ports:
       - "8080:80"
     environment:


### PR DESCRIPTION
This resolves #35 by removing all use of docker-compose v1 in favor of the docker compose v2 plugin.  Tested locally on a Windows machine by bringing up a system to the point of enabling TLS (but not enabling TLS), verifying site functionality, then turning down.