### PR TITLE
Improvements to `publish.sh`

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,19 +1,31 @@
 #!/bin/bash
 
-RW_SITE_VERSION=${1:?A version like v1.0.0 must be specified for this script}
-docker tag ropewiki/reverse_proxy:latest ropewiki/reverse_proxy:${RW_SITE_VERSION}
-docker push ropewiki/reverse_proxy:${RW_SITE_VERSION}
-docker push ropewiki/reverse_proxy:latest
-docker tag ropewiki/webserver:latest ropewiki/webserver:${RW_SITE_VERSION}
-docker push ropewiki/webserver:${RW_SITE_VERSION}
-docker push ropewiki/webserver:latest
-docker tag ropewiki/database:latest ropewiki/database:${RW_SITE_VERSION}
-docker push ropewiki/database:${RW_SITE_VERSION}
-docker push ropewiki/database:latest
-docker tag ropewiki/backup_manager:latest ropewiki/backup_manager:${RW_SITE_VERSION}
-docker push ropewiki/backup_manager:${RW_SITE_VERSION}
-docker push ropewiki/backup_manager:latest
-docker tag ropewiki/mailserver:latest ropewiki/mailserver:${RW_SITE_VERSION}
-docker push ropewiki/mailserver:${RW_SITE_VERSION}
-docker push ropewiki/mailserver:latest
-echo "Remember to create and push the git tag {$RW_SITE_VERSION}"
+# This script is to be ran after a successful deployment of the ropewiki stack.
+# It tags docker images and github commits with versions numbers which can be used in future as known "good versions".
+
+RW_SITE_VERSION=${1:?This script expects a version tag as the first argument. Run "git tag" to see current version tags.}
+
+images=(
+    "backup_manager"
+    "database"
+    "mailserver"
+    "reverse_proxy"
+    "webserver"
+)
+
+for image in "${images[@]}"; do
+    docker tag ropewiki/$image:latest ropewiki/$image:${RW_SITE_VERSION}
+    docker push ropewiki/$image:${RW_SITE_VERSION}
+    docker push ropewiki/$image:latest
+done
+
+echo
+echo "########################"
+echo
+echo "Remember to create and push the git tag $RW_SITE_VERSION. This needs to be done from a checkout with write access to github."
+echo "  git checkout $(git rev-parse HEAD)"
+echo "  git tag ${RW_SITE_VERSION}"
+echo "  git push origin ${RW_SITE_VERSION}"
+echo
+echo "########################"
+echo


### PR DESCRIPTION
Refactored `publish.sh` a bit so it's easier to understand.

I couldn't find a nice way to do the git tagging part locally (since it's using the http:// git end point, and keeps asking for a password - rather than the ssh:// one). So I just made it print the commands needs to be run elsewhere.

Tested by manually copying over to production and running it.

```
root@ropewiki:/rw/app# ./publish.sh
./publish.sh: line 6: 1: This script expects a version tag as the first argument. Run git tag to see current version tags.


root@ropewiki:/rw/app# ./publish.sh v1.3.0
The push refers to repository [docker.io/ropewiki/backup_manager]
286048513ca4: Layer already exists
61eb4cba0590: Layer already exists
025e024c0a86: Layer already exists
1ef4beed1a0a: Layer already exists
[...]
2033b354d55b: Layer already exists
ca1f97317925: Layer already exists
c4382d3b533e: Layer already exists
e9a77f28f01c: Layer already exists
6782f02f59a3: Layer already exists
f5bb4f853c84: Layer already exists
latest: digest: sha256:26de2a8b7572949b63394408f898299bc6e378180a0d6c817b08288c886596ec size: 10601

########################

Remember to create and push the git tag v1.3.0. This needs to be done from a checkout with write access to github.
  git checkout 21830528f8e67bc4043928ec163bf233eb4ffac6
  git tag v1.3.0
  git push origin v1.3.0

########################
```