### PR TITLE
Fix certbot auto-renewal & hands-free cert creation

### DIFF
--- a/reverse_proxy/Dockerfile
+++ b/reverse_proxy/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx
 
 RUN apt-get update
-RUN apt-get -y install certbot python3-certbot-nginx
+RUN apt-get -y install certbot python3-certbot-nginx procps less cron
 
 # Set up startup behavior
 COPY ./reverse_proxy/scripts/system_start.sh /root/system_start.sh

--- a/reverse_proxy/scripts/system_start.sh
+++ b/reverse_proxy/scripts/system_start.sh
@@ -14,4 +14,5 @@ else
 fi
 
 echo "RopeWiki reverse proxy running nginx..."
+cron &
 nginx -g "daemon off;"


### PR DESCRIPTION
Auto-renew of certificates should work now (certbot automatically sets it up). All it needed was cron running in the reverse_proxy container.

This PR:

 - Installs cron (and other basic tools), and runs `cron` at startup.
 - Makes the `enable_tls` deploy command more hands-free. It'll now automatically request certificates for both `$WG_HOSTNAME` and `www.$WG_HOSTNAME` without needing human input.
 - Deletes `add_cert_cronjob` which install a renewal cronjob on the VM, not inside the container (and didn't work because of #27).