### PR TITLE
Pause between creating search indexes and starting searchd

### DIFF
--- a/webserver/scripts/system_start.sh
+++ b/webserver/scripts/system_start.sh
@@ -29,6 +29,7 @@ sed -i "s/{{WG_DB_USER}}/$WG_DB_USER/g" sphinx.conf
 sed -i "s/{{WG_DB_PASSWORD}}/$WG_DB_PASSWORD/g" sphinx.conf
 echo Sphinx indexer started -- can take up to a minute
 indexer --config /etc/sphinxsearch/sphinx.conf --all
+sleep 2
 echo Sphinx indexer finished -- starting service
 searchd --config /etc/sphinxsearch/sphinx.conf >> /var/log/sphinxsearch/sphinx-startup.log 2>&1
 


### PR DESCRIPTION
Quick hack for the search index startup problem.

`searchd` starts really quickly, causing a race condition with the indexes being created...

```
precaching index 'wiki_main'
WARNING: index 'wiki_main': preload: failed to open /var/data/sphinx/wiki_main.sph: No such file or directory; NOT SERVING
precaching index 'wiki_incremental'
WARNING: index 'wiki_incremental': preload: failed to open /var/data/sphinx/wiki_incremental.sph: No such file or directory; NOT SERVING
FATAL: no valid indexes to serve
```

So just pause 2 seconds.