### PR TITLE
Tweak/client ip logs

### DIFF
--- a/webserver/nginx/nginx.conf
+++ b/webserver/nginx/nginx.conf
@@ -36,7 +36,9 @@ http {
 
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;
-
+    log_format combined '$remote_addr - $remote_user [$time_local] "$request" '
+                       '$status $body_bytes_sent "$http_referer" '
+                       '"$http_user_agent" "$http_x_forwarded_for"';
 	##
 	# Gzip Settings
 	##

--- a/webserver/nginx/nginx.conf
+++ b/webserver/nginx/nginx.conf
@@ -38,9 +38,6 @@ http {
 
 	access_log /var/log/nginx/access.log main;
 	error_log /var/log/nginx/error.log;
-    log_format combined '$remote_addr - $remote_user [$time_local] "$request" '
-                       '$status $body_bytes_sent "$http_referer" '
-                       '"$http_user_agent" "$http_x_forwarded_for"';
 	##
 	# Gzip Settings
 	##

--- a/webserver/nginx/nginx.conf
+++ b/webserver/nginx/nginx.conf
@@ -33,8 +33,10 @@ http {
 	##
 	# Logging Settings
 	##
+	log_format main '$http_x_forwarded_for $remote_addr - $remote_user [$time_local] "$request" '
+		'$status $body_bytes_sent "$http_referer" "$http_user_agent"';
 
-	access_log /var/log/nginx/access.log;
+	access_log /var/log/nginx/access.log main;
 	error_log /var/log/nginx/error.log;
     log_format combined '$remote_addr - $remote_user [$time_local] "$request" '
                        '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
This logs the visitor's actual IP logged by the webserver nginx.

```
75.172.125.37 172.19.0.6 - - [25/Jul/2023:22:05:55 +0000] "GET /Davis_Creek_Canyon HTTP/1.0" 200 84891 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0"
```
The first IP is that stored in the X_FORWARDED_FOR http header by the reverse proxy. The second is the IP of the TCP connection (i.e. the reverse proxy itself).

Local requests (e.g. from scripts etc) will look like this:
```
- 127.0.0.1 - - [25/Jul/2023:22:07:44 +0000] "POST /index.php?title=Special%3ARunJobs&tasks=jobs&maxjobs=1&sigexpiry=1690322 HTTP/1.1" 202 5 "-" "-"
```