### PR TITLE
Adjust mysql settings + add tools

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -3,3 +3,14 @@
 
 # MySQL database; see https://hub.docker.com/_/mysql
 FROM mysql:5.7-debian
+
+# These values were suggested by mysqltuner.pl after the database
+# had been running multiple days and was under sustained load.
+RUN echo key_buffer_size=64M >> /etc/mysql/mysql.conf.d/mysqld.cnf
+RUN echo innodb_buffer_pool_size=4G >> /etc/mysql/mysql.conf.d/mysqld.cnf
+RUN echo innodb_log_file_size=512M >> /etc/mysql/mysql.conf.d/mysqld.cnf
+RUN echo innodb_buffer_pool_instances=4 >> /etc/mysql/mysql.conf.d/mysqld.cnf
+
+# Add helpful tools
+RUN apt update && apt install -y vim wget curl less
+RUN wget mysqltuner.pl -O /mysqltuner.pl && chmod 755 /mysqltuner.pl


### PR DESCRIPTION
These settings were suggested by mysqltuner.pl and have been active on the production database for >24hrs.

The database is stable, and *seems* to be performing better (i.e. load is significantly down) - but things were also added to the ip block list at the same time, so cause isn't 100% clear.

Tested docker changes locally, and config + tooling appears as expected.