### PR TITLE
Add blocklist of known bad URLs

### DIFF
--- a/reverse_proxy/blockips.conf
+++ b/reverse_proxy/blockips.conf
@@ -1,6 +1,18 @@
 # Note: Changes to this file require rebuilding the ropewiki/reverse_proxy
 # image; see Dockerfile in this folder.
 
+# Block know bad URLs
+map $request_uri $block_request {
+    default 0;
+
+    # bots trying to exploit remote fetching
+    "~*^/Weather\?location=http" 1;
+
+    # bots trying to exploit wordpress sites
+    "~*^/wp-login\.php" 1;
+    "~*^/xmlrpc\.php" 1;
+}
+
 deny 117.52.74.20;
 deny 157.55.39.218;
 deny 174.164.160.6;

--- a/reverse_proxy/services.conf
+++ b/reverse_proxy/services.conf
@@ -21,6 +21,12 @@ server {
   server_name {{WG_HOSTNAME}};
 
   location / {
+    # Check for blocked URLs defined in blockips.conf
+    if ($block_request) {
+        # HTTP 444 - a special nginx status to drop the connection
+        # without sending *any* response.
+        return 444;
+    }
     proxy_pass http://ropewiki_local/;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }


### PR DESCRIPTION
This extends our blocking to drop requests for specific known bad URLs we shouldn't waste any cpu cycles processing.

Watching the logs, requests for these come in a few times a minute.

Examples of bad urls:

 - bots exploiting pages which fetch external content:
```
GET /Weather?location=http%3a%2f%2fleewhan.com%2Fbbs%2Fboard.php
GET /Weather?location=http%3a%2f%2fbethongkongpools.com
```

 - bots scanning for vulnerable wordpress endpoints:

```
GET /xmlrpc.php
GET /wp-login.php
```

We return a HTTP 444, which is a specific nginx code that drops the connection without sending a response (why should we even respond to known malicious traffic!).

Tested locally & manually in production. Results when fetching a blocked URL:

![image](https://github.com/RopeWiki/app/assets/131580/b36f1578-7bae-4124-b51b-9aa9b92d2a60)
