### PR TITLE
nginx log changes & `goaccess` log parsing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,6 +72,7 @@ services:
       - ropewiki_webserver
     volumes:
       - ropewiki_proxy_certs:/etc/letsencrypt
+      - ropewiki_proxy_logs:/logs
 #    restart: always
 
   # The RopeWiki backup manager; see instructions in README.md to build the image
@@ -119,3 +120,5 @@ volumes:
     name: ropewiki_database_storage
   ropewiki_proxy_certs:
     name: ropewiki_proxy_certs
+  ropewiki_proxy_logs:
+    name: ropewiki_proxy_logs

--- a/reverse_proxy/Dockerfile
+++ b/reverse_proxy/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx
 
 RUN apt-get update
-RUN apt-get -y install certbot python3-certbot-nginx
+RUN apt-get -y install certbot python3-certbot-nginx goaccess procps vim less wget curl
 
 # Set up startup behavior
 COPY ./reverse_proxy/scripts/system_start.sh /root/system_start.sh

--- a/reverse_proxy/nginx.conf
+++ b/reverse_proxy/nginx.conf
@@ -2,41 +2,35 @@
 # image; see Dockerfile in this folder.
 
 user  nginx;
-worker_processes  1;
+worker_processes  auto;
 
-error_log  /var/log/nginx/error.log warn;
+error_log  /logs/nginx/error.log warn;
 pid        /var/run/nginx.pid;
-
 
 events {
     worker_connections  1024;
 }
-
 
 http {
     include       /etc/nginx/blockips.conf;
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] $host "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /logs/nginx/access.log combined;
 
-    access_log  /var/log/nginx/access.log  main;
-
-	sendfile on;
-	tcp_nopush on;
-	tcp_nodelay on;
-	keepalive_timeout 65;
-	types_hash_max_size 2048;
-	server_tokens off;
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    server_tokens off;
 
     client_max_body_size 20m;
     client_body_timeout 60;
     client_body_buffer_size 128k;
 
-	gzip on;
-	gzip_disable "msie6";
+    gzip on;
+    gzip_disable "msie6";
 
     include /etc/nginx/services.conf;
 }

--- a/reverse_proxy/scripts/system_start.sh
+++ b/reverse_proxy/scripts/system_start.sh
@@ -8,10 +8,26 @@ else
   echo "Configuring nginx services..."
   sed -i "s/{{WG_HOSTNAME}}/$WG_HOSTNAME/g" /etc/nginx/services.conf
 
+  mkdir -p /logs/goaccess/db
+  mkdir -p /logs/nginx
+  touch /logs/nginx/access.log
   touch /ropewiki_setup_complete
 
   echo "<<< RopeWiki reverse proxy prep complete."
 fi
+
+echo "Starting up goaccess log parsing..."
+goaccess /logs/nginx/access.log \
+  -o /logs/goaccess/report.html \
+  --log-format COMBINED \
+  --real-time-html \
+  --ws-url wss://$WG_HOSTNAME:443/reportws \
+  --daemonize \
+  --db-path /logs/goaccess/db \
+  --restore \
+  --persist \
+  --html-refresh 10 \
+  --html-report-title "Ropewiki Stats"
 
 echo "RopeWiki reverse proxy running nginx..."
 nginx -g "daemon off;"

--- a/reverse_proxy/services.conf
+++ b/reverse_proxy/services.conf
@@ -25,13 +25,26 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
+  # websocket for live updating goaccess
+  location /reportws {
+    proxy_pass http://localhost:7890;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+
+  # goaccess html file
+  location = /report.html {
+    alias /logs/goaccess/report.html;
+  }
+
   location /luca {
     proxy_pass http://luca_remote;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
   # This line logs accesses to this service
-  access_log /var/log/nginx/access.log main;
+  access_log /logs/nginx/access.log combined;
 }
 
 server {


### PR DESCRIPTION
 - create a new volume for the proxy logs, mounted as `/logs`
 - change nginx log location to use the volume
 - change log format to the standard "combined" format rather than a customer one (to make parsing much easier).
 - install the `goaccess` package (+ other useful tools)
 - setup two new nginx endpoints, one to server the static html of `goaccess`, and another to handle its websocket for live updates.
 - minor tweaks to nginx config (whitespace, automatically pick number of workers based on number of cpus).

Note: these logging changes mean nginx will no longer log to stdout, which means `docker log` will not show the logs. This isn't actually a big problem, as `docker logs` on kept 10M of logs anyhow. This now matches what the webserver container does too.

Testing: tested locally. Also tested in prod by checking out this branch and updating the reverse_proxy container. At the moment you can see the results here: https://ropewiki.com/report.html