### PR TITLE
Add user-agent blocking to the reverse proxy

### DIFF
--- a/reverse_proxy/blockips.conf
+++ b/reverse_proxy/blockips.conf
@@ -1,8 +1,8 @@
 # Note: Changes to this file require rebuilding the ropewiki/reverse_proxy
 # image; see Dockerfile in this folder.
 
-# Block know bad URLs
-map $request_uri $block_request {
+# Block known bad URLs
+map $request_uri $block_uri {
     default 0;
 
     # bots trying to exploit remote fetching
@@ -11,6 +11,15 @@ map $request_uri $block_request {
     # bots trying to exploit wordpress sites
     "~*^/wp-login\.php" 1;
     "~*^/xmlrpc\.php" 1;
+}
+
+# Block known bad User-Agents
+map $http_user_agent $block_agent {
+    default         0;
+    # A nasty persistent crawler running in AWS
+    ~*Bytespider    1;
+    # Amazon will just not let-up despite robots.txt
+    ~*Amazonbot     1;
 }
 
 # Bingbot/MSNBot

--- a/reverse_proxy/services.conf
+++ b/reverse_proxy/services.conf
@@ -21,12 +21,11 @@ server {
   server_name {{WG_HOSTNAME}};
 
   location / {
-    # Check for blocked URLs defined in blockips.conf
-    if ($block_request) {
-        # HTTP 444 - a special nginx status to drop the connection
-        # without sending *any* response.
-        return 444;
-    }
+    # Check for block rules defined in blockips.conf
+    # 444 is a special nginx code which drops the connection with no response.
+    if ($block_uri) { return 444; }
+    if ($block_agent) { return 444; }
+    
     proxy_pass http://ropewiki_local/;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }


### PR DESCRIPTION
Getting pretty sick of seeing the same user agents hammering away at the site - and chasing IP addresses is futile in the long run.

Lets get more serious and just drop requests from the worst user agents.

Tested by hot-fixing into production and checking the logs...

Request from Amazonbot being returned a 444
```
23.22.35.162 - - [18/Aug/2023:19:27:39 +0000] "GET /index.php?action=edit&redlink=1&title=File_talk:Little_Bighorn_Canyon.kml HTTP/1.1" 444 0 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Amazonbot/0.1; +https://developer.amazon.com/
support/amazonbot)"
```

Whereas other requests being handled like normal.