### PR TITLE
Enable php-apcu caching (per mediawiki docs)

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get install -y --no-install-recommends software-properties-common && \
     printf '#!/bin/sh\nexit 0' > /usr/sbin/policy-rc.d && \
     apt-get install -y --no-install-recommends \
         php5.6 \
+        php5.6-apcu \
         php5.6-fpm \
         php5.6-cli \
         php5.6-mysql \
@@ -40,7 +41,7 @@ RUN apt-get install -y --no-install-recommends software-properties-common && \
 RUN pear install --alldeps mail
 
 # Install various tools
-RUN apt-get install -y --no-install-recommends wget unzip git nano sed curl imagemagick less
+RUN apt-get install -y --no-install-recommends wget unzip git nano sed curl imagemagick less vim
 
 # Install composer
 # https://stackoverflow.com/a/51446468/651139

--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -59,8 +59,8 @@ $wgDBTableOptions   = "ENGINE=InnoDB, DEFAULT CHARSET=utf8";
 $wgDBmysql5 = false;
 
 ## Shared memory settings
-$wgMainCacheType    = CACHE_NONE;
-#$wgMainCacheType    = CACHE_ACCEL;
+#$wgMainCacheType    = CACHE_NONE;
+$wgMainCacheType    = CACHE_ACCEL;
 $wgMemCachedServers = array();
 
 ## To enable image uploads, make sure the 'images' directory


### PR DESCRIPTION
Further work to improve site performance. This time by enabling php's in-memory key value store.

The mediawiki docs related to this: https://www.mediawiki.org/wiki/Manual:Performance_tuning#Object_caching

Page load times do seem to come down by about half a second with this enabled.

![image](https://github.com/RopeWiki/app/assets/131580/9a2670ba-9161-43c8-9bdc-4ccd9d7f59b5)
