### PR TITLE
Remove port 8080 from webserver container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,8 +36,6 @@ services:
       dockerfile: webserver/Dockerfile
       args:
         codebaseversion: ${CODEBASE_VERSION:-When this image was built with docker compose, <pre>CODEBASE_VERSION</pre> environment variable was not present.}
-    ports:
-      - "8080:80"
     environment:
       - WG_PROTOCOL=${WG_PROTOCOL:-http}
       - WG_HOSTNAME=${WG_HOSTNAME:-localhost:8080}


### PR DESCRIPTION
Despite `ufw` not allowing port 8080 from the internet, Docker adds its own iptables rules to permit any exposed container ports.

This is a problem because we've been hit by bots directly on port 8080, which bypass protections the reverse proxy provides.

So this PR is the real fix - no longer expose the port.

On the internal network the reverse proxy can still access the web server fine on port 80.



```
~: iptables -L -n -t nat

Chain DOCKER (2 references)
target     prot opt source               destination
RETURN     all  --  0.0.0.0/0            0.0.0.0/0
RETURN     all  --  0.0.0.0/0            0.0.0.0/0
DNAT       tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:8080 to:172.19.0.5:80   <--- the bad line.
DNAT       tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:443 to:172.19.0.6:443
DNAT       tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:80 to:172.19.0.6:80
DNAT       tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:22001 to:172.19.0.4:22
```

After rebuilding and redeploying the webserver docker image, this line of iptables goes away, and direct connections from the internet fail.