### PR TITLE
Update bot protections

### DIFF
--- a/reverse_proxy/blockips.conf
+++ b/reverse_proxy/blockips.conf
@@ -20,38 +20,18 @@ map $http_user_agent $block_agent {
     ~*Bytespider    1;
     # Amazon will just not let-up despite robots.txt
     ~*Amazonbot     1;
+    # Ignores robots.txt
+    ~*SemrushBot    1;
+    # Yeah, Yandex can FO.
+    ~*YandexBot        1;
+    ~*YandexRenderResourcesBot        1;
 }
-
-# Bingbot/MSNBot
-deny 157.55.39.218;
-deny 40.77.167.171;
-
-# Microsoft (not bing)
-deny 40.83.2.0/24;
-
-# semrush
-deny 185.191.171.0/24;
-deny 85.208.96.0/24;
 
 # vodafonedsl.it
 deny 193.150.70.0/24;
 
 # Private Internet Hosting LTD
 deny 193.218.190.0/24;
-
-# Amazon
-deny 23.22.35.162;
-deny 3.224.220.101;
-deny 52.70.240.171;
-
-# SeekportBot
-deny 65.108.41.9;
-
-# Googlebot
-deny 66.249.79.0/24;
-
-# Yandex
-deny 95.108.213.0/24;
 
 # Unknown abuse
 deny 89.46.109.205;

--- a/webserver/robots/robots_prod.txt
+++ b/webserver/robots/robots_prod.txt
@@ -1,6 +1,7 @@
 user-agent: *
 allow: /
 disallow: /luca/
+crawl-delay: 5
 
 user-agent: Amazonbot
 disallow: /


### PR DESCRIPTION
This cleans up a few bot related things.

 - Remove the google block. (2 people have asked me what's recently happened to ropewiki's google results as they've gone to crap, whereas duckduckgo is still good - this explains why).
 - Move Yandex & Semrush blocks from IP to more robust useragent block
 - Seekport is a nice bot and follows robots.txt since they were added there.
 - Amazon is already blocked by useragent so no need for IP block
 - The MS/Bing bots have switches to different IPs and already bypassed the IP-block and crawling the site. I also thing allowing Bing to crawl is an ok idea - weirdly people do actually use it.
 
 Also adds the `crawl-delay` option to tell good bots to back-off a bit (one request per 5 seconds).
 
Deployed locally and confirmed all services start up correctly.