### PR TITLE
Make page actions use short urls (`/edit`, `/history`, etc).

### DIFF
--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -314,3 +314,29 @@ if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
         $clientIP = trim($ips[0]);
         $_SERVER['REMOTE_ADDR'] = $clientIP;
 }
+
+# Make short urls for actions
+#   Before: ropewiki.com/index.php?title=Lewis_River&action=formedit
+#   After: ropewiki.com/Lewis_River/formedit
+$actions = array(
+    'delete',
+    'edit',
+    'formedit',
+    'history',
+    'info'
+    'markpatrolled',
+    'protect',
+    'purge',
+    'render',
+    'revert',
+    'rollback',
+    'submit',
+    'unprotect',
+    'unwatch',
+    'watch',
+    // 'view',  # view is the default action so doesn't need its own path
+);
+
+foreach ( $actions as $action ) {
+    $wgActionPaths[ $action ] = "/$1/$action";
+}

--- a/webserver/robots/robots_prod.txt
+++ b/webserver/robots/robots_prod.txt
@@ -1,6 +1,8 @@
 user-agent: *
 allow: /
 disallow: /luca/
+disallow: /api.php
+disallow: /Special:
 crawl-delay: 5
 
 user-agent: Amazonbot


### PR DESCRIPTION
This makes actions use the same short URLs as viewing pages do.

This makes things a lot neater, and also tidies up SEO, as we don't have pages being indexed via two different URLs.

Tested locally, screenshots attached. Followed these instructions: https://www.mediawiki.org/wiki/Manual:$wgActionPaths

Example:

* Before:
https://ropewiki.com/index.php?title=Lewis_River&action=formedit

* After:
https://ropewiki.com/Lewis_River/formedit

![2023-09-03 14_08_22-Editing Boston Creek - ropewiki — Mozilla Firefox](https://github.com/RopeWiki/app/assets/131580/98a22eea-65d2-4866-99b7-e926c715fece)

![2023-09-03 14_08_39-Revision history of _Boston Creek_ - ropewiki — Mozilla Firefox](https://github.com/RopeWiki/app/assets/131580/3a23ed2c-d213-4c80-935c-1d9f4fadb26b)

![2023-09-03 14_09_26-Edit Canyon_ Boston Creek - ropewiki — Mozilla Firefox](https://github.com/RopeWiki/app/assets/131580/ee67f361-4f22-482c-b95c-c6b00571103c)
