### PR TITLE
Switch db restore user from ropewiki to root

### DIFF
--- a/deploy_tool.py
+++ b/deploy_tool.py
@@ -354,10 +354,10 @@ def load_sql(site_config: SiteConfig, backup_path: str):
 
   log('Loading {}...'.format(backup_path))
   log('  (NOTE: this operation usually takes a few minutes)')
-  cmd = '{cat_tool} {backup_path} | docker container exec -i {db_container} mysql -uropewiki -p{db_password} --host {db_hostname} ropewiki'
+  cmd = '{cat_tool} {backup_path} | docker container exec -i {db_container} mysql -uroot -p{root_db_password} --host {db_hostname} ropewiki'
   cmd = cmd.format(
     cat_tool=cat_tool, backup_path=backup_path, db_container=site_config.backup_manager_container,
-    db_password=site_config.db_password, db_hostname=site_config.db_hostname)
+    root_db_password=site_config.root_db_password, db_hostname=site_config.db_hostname)
   run_cmd(cmd)
   log('  -> Backup restored.')
 


### PR DESCRIPTION
#30 added the `--all-databases` flag to the backup manager (which is a good thing).

However it means the restore tool needs access to more than just the ropewiki db to restore the full backup.

```
ropewiki2:/rw# ./deploy_tool.py ak restore_db
Restore /rw/mount/sqlbackup/all-backup-2023-09-04-100002.sql? (y/n): y
2023-09-06T03:35:00.944603 Ensuring backup manager is available...
2023-09-06T03:35:00.944712   RUN git log -n 1
2023-09-06T03:35:00.954695   RUN git status
2023-09-06T03:35:00.958578   SCRIPT docker compose -p ak up -d ropewiki_backup_manager
2023-09-06T03:35:00.958602   RUN sh /rw/docker_compose_command.sh && rm /rw/docker_compose_command.sh
[+] Running 2/0
 ✔ Container ak-ropewiki_db-1              Running
 ✔ Container ak-ropewiki_backup_manager-1  Running
0.0s 2023-09-06T03:35:01.020922 Loading /rw/mount/sqlbackup/all-backup-2023-09-04-100002.sql...
2023-09-06T03:35:01.020954   (NOTE: this operation usually takes a few minutes)
2023-09-06T03:35:01.020979   RUN cat /rw/mount/sqlbackup/all-backup-2023-09-04-100002.sql | docker container
      exec -i ak-ropewiki_backup_manager-1 mysql -uroot -p......................
mysql: [Warning] Using a password on the command line interface can be insecure.
2023-09-06T03:38:01.026064   -> Backup restored.
```
