### PR TITLE
Increase file upload limit

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -47,6 +47,10 @@ RUN apt-get install -y --no-install-recommends wget unzip git nano sed curl imag
 # https://stackoverflow.com/a/51446468/651139
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
+# Bump file size upload limit
+RUN sed -i 's/^upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php/5.6/fpm/php.ini
+RUN sed -i 's/^post_max_size.*/post_max_size = 10M/' /etc/php/5.6/fpm/php.ini
+
 # === Install MediaWiki ===
 
 # Retrieve MediaWiki installation package and follow installation instructions:

--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -283,7 +283,7 @@ $egMapsCoordinateDirectional = false;
 $egMapsGMaps3ApiKey = "";
 $egMapsGMaps3ApiVersion = ""; 
 
-#Didn't work?
+# Upload limits are set in php.ini (upload_max_filesize)
 #$wgUploadSizeWarning = 5242880;
 #$wgMaxUploadSize = 5242880;
 


### PR DESCRIPTION
I strongly suspect the site ran with a higher upload limit in the past, but we've been using the php default since migrating the backend infra (2MB).

Let's make it something sensible for 2023 (10MB).

Tested locally:

![image](https://github.com/RopeWiki/app/assets/131580/99edc5fb-fa74-433e-ac98-e9c9346363d2)
