### PR TITLE
docker containers should restart unless explicitly stopped

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       - MYSQL_ROOT_PASSWORD=${RW_ROOT_DB_PASSWORD:-thispasswordonlyworksuntildbisrestored}
     volumes:
       - ropewiki_database_storage:/var/lib/mysql
-#    restart: always
+    restart: unless-stopped
 
   # The main RopeWiki server running MediaWiki; see instructions in README.md to build the image
   ropewiki_webserver:
@@ -47,7 +47,7 @@ services:
       - ropewiki_db
     volumes:
       - ${IMAGES_FOLDER:?IMAGES_FOLDER environment variable must be set}:/usr/share/nginx/html/ropewiki/images
-    #restart: always
+    restart: unless-stopped
 
   # The reverse proxy that directs traffic to the appropriate places; see instructions in README.md to build the image
   ropewiki_reverse_proxy:
@@ -71,7 +71,7 @@ services:
     volumes:
       - ropewiki_proxy_certs:/etc/letsencrypt
       - ropewiki_proxy_logs:/logs
-#    restart: always
+    restart: unless-stopped
 
   # The RopeWiki backup manager; see instructions in README.md to build the image
   ropewiki_backup_manager:
@@ -90,7 +90,7 @@ services:
     volumes:
       - ${SQL_BACKUP_FOLDER:?SQL_BACKUP_FOLDER environment variable must be set}:/home/backupreader/backups
       - ${IMAGES_FOLDER:?IMAGES_FOLDER environment variable must be set}:/home/backupreader/images:ro
-#    restart: always
+    restart: unless-stopped
 
   ropewiki_mailserver:
     image: ropewiki/mailserver


### PR DESCRIPTION
The db container stopped (for a yet undetermined reason). Had it been set to auto restart the site would have stayed online :-)

The `unless-stopped` stopped option means you can manually stop containers with docker restarting them later.