### PR TITLE
Tweaks to help troubleshoot php-fpm stalling issue

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -11,6 +11,11 @@ RUN echo innodb_buffer_pool_size=4G >> /etc/mysql/mysql.conf.d/mysqld.cnf
 RUN echo innodb_log_file_size=512M >> /etc/mysql/mysql.conf.d/mysqld.cnf
 RUN echo innodb_buffer_pool_instances=4 >> /etc/mysql/mysql.conf.d/mysqld.cnf
 
+# Enable mysql slow query log
+RUN echo slow_query_log=1 >> /etc/mysql/mysql.conf.d/mysqld.cnf
+RUN echo slow_query_log_file=/var/log/mysql/mysql-slow.log >> /etc/mysql/mysql.conf.d/mysqld.cnf
+RUN echo long_query_time=1 >> /etc/mysql/mysql.conf.d/mysqld.cnf
+
 # Add helpful tools
 RUN apt update && apt install -y vim wget curl less
 RUN wget mysqltuner.pl -O /mysqltuner.pl && chmod 755 /mysqltuner.pl

--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -51,6 +51,15 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN sed -i 's/^upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php/5.6/fpm/php.ini
 RUN sed -i 's/^post_max_size.*/post_max_size = 10M/' /etc/php/5.6/fpm/php.ini
 
+# Optimize php-fpm configs
+RUN sed -i 's/^emergency_restart_threshold.*/emergency_restart_threshold = 10/' /etc/php/5.6/fpm/php-fpm.conf
+RUN sed -i 's/^emergency_restart_interval.*/emergency_restart_interval = 1m/' /etc/php/5.6/fpm/php-fpm.conf
+RUN sed -i 's/^process_control_timeout.*/process_control_timeout = 10s/' /etc/php/5.6/fpm/php-fpm.conf
+
+RUN sed -i 's/^request_terminate_timeout.*/request_terminate_timeout = 30s/' /etc/php/5.6/fpm/pool.d/www.conf
+RUN sed -i 's/^process_idle_timeout.*/process_idle_timeout = 30s/' /etc/php/5.6/fpm/pool.d/www.conf
+
+
 # === Install MediaWiki ===
 
 # Retrieve MediaWiki installation package and follow installation instructions:


### PR DESCRIPTION
These are settings I've already applied in production to help fix the weird php stalling issue, which we have to solve by restarting php-fpm.

```
emergency_restart_threshold
emergency_restart_interval
process_control_timeout
request_terminate_timeout
process_idle_timeout
```

It also enabled the mysql slow query log, so we can identify heavy weight queries.