### PR TITLE
Fix php config comments

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -48,16 +48,16 @@ RUN apt-get install -y --no-install-recommends wget unzip git nano sed curl imag
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Bump file size upload limit
-RUN sed -i 's/^upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php/5.6/fpm/php.ini
-RUN sed -i 's/^post_max_size.*/post_max_size = 10M/' /etc/php/5.6/fpm/php.ini
+RUN sed -i 's/^;\?upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php/5.6/fpm/php.ini
+RUN sed -i 's/^;\?post_max_size.*/post_max_size = 10M/' /etc/php/5.6/fpm/php.ini
 
 # Optimize php-fpm configs
-RUN sed -i 's/^emergency_restart_threshold.*/emergency_restart_threshold = 10/' /etc/php/5.6/fpm/php-fpm.conf
-RUN sed -i 's/^emergency_restart_interval.*/emergency_restart_interval = 1m/' /etc/php/5.6/fpm/php-fpm.conf
-RUN sed -i 's/^process_control_timeout.*/process_control_timeout = 10s/' /etc/php/5.6/fpm/php-fpm.conf
+RUN sed -i 's/^;\?emergency_restart_threshold.*/emergency_restart_threshold = 10/' /etc/php/5.6/fpm/php-fpm.conf
+RUN sed -i 's/^;\?emergency_restart_interval.*/emergency_restart_interval = 1m/' /etc/php/5.6/fpm/php-fpm.conf
+RUN sed -i 's/^;\?process_control_timeout.*/process_control_timeout = 10s/' /etc/php/5.6/fpm/php-fpm.conf
 
-RUN sed -i 's/^request_terminate_timeout.*/request_terminate_timeout = 30s/' /etc/php/5.6/fpm/pool.d/www.conf
-RUN sed -i 's/^process_idle_timeout.*/process_idle_timeout = 30s/' /etc/php/5.6/fpm/pool.d/www.conf
+RUN sed -i 's/^;\?request_terminate_timeout.*/request_terminate_timeout = 30s/' /etc/php/5.6/fpm/pool.d/www.conf
+RUN sed -i 's/^;\?process_idle_timeout.*/process_idle_timeout = 30s/' /etc/php/5.6/fpm/pool.d/www.conf
 
 
 # === Install MediaWiki ===


### PR DESCRIPTION
Argh. The previous logic didn't handle when the config options were commented out originally. So the options weren't actually being enabled!

Re-tested with a fresh container...

```
root@ropewiki_webserver:/# grep -vP '(^;|^$|^[[:space:]]+$)' /etc/php/5.6/fpm/pool.d/www.conf
[www]
user = www-data
group = www-data
listen = /run/php/php5.6-fpm.sock
listen.owner = www-data
listen.group = www-data
pm = dynamic
pm.max_children = 16
pm.start_servers = 2
pm.min_spare_servers = 1
pm.max_spare_servers = 3
request_terminate_timeout = 30s
```

```
root@ropewiki_webserver:/# grep -vP '(^;|^$|^[[:space:]]+$)' /etc/php/5.6/fpm/php-fpm.conf
include=/etc/php/5.6/fpm/pool.d/*.conf
[global]
pid = /run/php/php5.6-fpm.pid
error_log = /var/log/php5.6-fpm.log
emergency_restart_threshold = 10
emergency_restart_interval = 1m
process_control_timeout = 10s
```

Options now present as expected!