### PR TITLE
Performance & Stability changes (and some repo housekeeping)

### DIFF
--- a/fpm-pool.conf
+++ b/fpm-pool.conf
@@ -1,0 +1,24 @@
+[www]
+
+
+user = www-data
+group = www-data
+
+listen = /run/php/php5.6-fpm.sock
+
+
+listen.owner = www-data
+listen.group = www-data
+
+#pm = dynamic
+pm.max_children = 16
+#pm.start_servers = 2
+#pm.min_spare_servers = 1
+#pm.max_spare_servers = 3
+
+pm = ondemand
+pm.max_children = 16
+pm.process_idle_timeout = 10s
+pm.max_requests = 200
+
+request_terminate_timeout = 30s

--- a/reverse_proxy/scripts/system_start.sh
+++ b/reverse_proxy/scripts/system_start.sh
@@ -16,18 +16,19 @@ else
   echo "<<< RopeWiki reverse proxy prep complete."
 fi
 
-echo "Starting up goaccess log parsing..."
-goaccess /logs/nginx/access.log \
-  -o /logs/goaccess/report.html \
-  --log-format COMBINED \
-  --real-time-html \
-  --ws-url wss://$WG_HOSTNAME:443/reportws \
-  --daemonize \
-  --db-path /logs/goaccess/db \
-  --restore \
-  --persist \
-  --html-refresh 10 \
-  --html-report-title "Ropewiki Stats"
+## While we're short on CPU, disable log constant parsing
+#echo "Starting up goaccess log parsing..."
+#goaccess /logs/nginx/access.log \
+#  -o /logs/goaccess/report.html \
+#  --log-format COMBINED \
+#  --real-time-html \
+#  --ws-url wss://$WG_HOSTNAME:443/reportws \
+#  --daemonize \
+#  --db-path /logs/goaccess/db \
+#  --restore \
+#  --persist \
+#  --html-refresh 10 \
+#  --html-report-title "Ropewiki Stats"
 
 echo "RopeWiki reverse proxy running nginx..."
 nginx -g "daemon off;"

--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -56,8 +56,8 @@ RUN sed -i 's/^;\?emergency_restart_threshold.*/emergency_restart_threshold = 10
 RUN sed -i 's/^;\?emergency_restart_interval.*/emergency_restart_interval = 1m/' /etc/php/5.6/fpm/php-fpm.conf
 RUN sed -i 's/^;\?process_control_timeout.*/process_control_timeout = 10s/' /etc/php/5.6/fpm/php-fpm.conf
 
-RUN sed -i 's/^;\?request_terminate_timeout.*/request_terminate_timeout = 30s/' /etc/php/5.6/fpm/pool.d/www.conf
-RUN sed -i 's/^;\?process_idle_timeout.*/process_idle_timeout = 30s/' /etc/php/5.6/fpm/pool.d/www.conf
+# php-fpm pool settings
+COPY ./webserver/fpm-pool.conf /etc/php/5.6/fpm/pool.d/www.conf
 
 
 # === Install MediaWiki ===
@@ -107,7 +107,7 @@ RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extens
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-Variables Variables && cd Variables && git checkout 6f4bbd0
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-PdfHandler PdfHandler && cd PdfHandler && git checkout 5e29202
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-googleAnalytics googleAnalytics && cd googleAnalytics && git checkout ce5ef02
-RUN cd /rw/extensions && git clone https://gitlab.com/troyengel/Preloader && cd Preloader && git checkout 4b06d0e3
+RUN cd /rw/extensions && git clone https://gitlab.com/nornagon/Preloader && cd Preloader && git checkout 02539e0
 RUN cd /rw/extensions && git clone https://github.com/RopeWiki/SemanticForms && cd SemanticForms && git checkout 9169c63
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-skins-Vector Vector && cd Vector && git checkout fad72e2
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-MultimediaViewer.git MultimediaViewer && cd MultimediaViewer && git checkout REL1_24


### PR DESCRIPTION
* Change the repo for `Preloader` module from `troyengel/Preloader` to a forked mirror at `nornagon/Preloader` (old repo went offline and broke container building).

* Update the php-fpm config (`pool.d/www.conf`) with recent changes to help stability (and give it a dedicated file rather than `sed`ing the config line by line).

* Disable `goaccess` to save a bit of CPU while the machine seem constantly busy.