### PR TITLE
Allow luca/caltopo access from aws

### DIFF
--- a/reverse_proxy/blockips.conf
+++ b/reverse_proxy/blockips.conf
@@ -1,6 +1,10 @@
 # Note: Changes to this file require rebuilding the ropewiki/reverse_proxy
 # image; see Dockerfile in this folder.
 
+# Allow specific clients who would otherwise be caught up in our AWS blockade
+allow 3.87.207.135;  # Luca Server (e.g. gpx processing)
+allow 54.67.34.1;  # CalTopo (e.g. "open with caltopo" link).
+
 # Block known bad URLs
 map $request_uri $block_uri {
     default 0;


### PR DESCRIPTION
These clients were being caught in our AWS blockage. Add a specific rule to allow them.