### PR TITLE
Add “index.php” to robots.txt

### DIFF
--- a/webserver/robots/robots_prod.txt
+++ b/webserver/robots/robots_prod.txt
@@ -11,8 +11,6 @@ disallow: /*/formedit
 disallow: /*/history
 disallow: /*/info
 disallow: /*?*
-
-
 crawl-delay: 5
 
 user-agent: Amazonbot

--- a/webserver/robots/robots_prod.txt
+++ b/webserver/robots/robots_prod.txt
@@ -3,7 +3,16 @@ allow: /
 disallow: /luca/
 disallow: /api.php
 disallow: /Special:
+disallow: /Votes:
+disallow: /Talk:
 disallow: /index.php
+disallow: /*/edit
+disallow: /*/formedit
+disallow: /*/history
+disallow: /*/info
+disallow: /*?*
+
+
 crawl-delay: 5
 
 user-agent: Amazonbot

--- a/webserver/robots/robots_prod.txt
+++ b/webserver/robots/robots_prod.txt
@@ -3,6 +3,7 @@ allow: /
 disallow: /luca/
 disallow: /api.php
 disallow: /Special:
+disallow: /index.php
 crawl-delay: 5
 
 user-agent: Amazonbot


### PR DESCRIPTION
Crawler’s are double-crawling the site because they visit the short URL and long URL, e.g.

  https://ropewiki.com/Davis_Creek_Canyon

and 

  https://ropewiki.com/index.php?page=Davis_Creek_Canyon

We should prefer the short version, and actually track down any places which are still using index.php in links.