### PR TITLE
Fix mysql repo key issues

### DIFF
--- a/backup_manager/Dockerfile
+++ b/backup_manager/Dockerfile
@@ -5,6 +5,11 @@
 
 FROM mysql:5.7-debian
 
+# Fix for apt key errors in the ancient version of debian/mysql we're running.
+RUN gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B7B3B788A8D3785C
+RUN rm /etc/apt/keyrings/mysql.gpg
+RUN gpg --output /etc/apt/keyrings/mysql.gpg --export B7B3B788A8D3785C
+
 # Install necessary tools
 RUN apt-get update && apt-get -y install \
     cron \

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -4,6 +4,11 @@
 # MySQL database; see https://hub.docker.com/_/mysql
 FROM mysql:5.7-debian
 
+# Fix for apt key errors in the ancient version of debian/mysql we're running.
+RUN gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B7B3B788A8D3785C
+RUN rm /etc/apt/keyrings/mysql.gpg
+RUN gpg --output /etc/apt/keyrings/mysql.gpg --export B7B3B788A8D3785C
+
 # These values were suggested by mysqltuner.pl after the database
 # had been running multiple days and was under sustained load.
 RUN echo key_buffer_size=64M >> /etc/mysql/mysql.conf.d/mysqld.cnf


### PR DESCRIPTION
The way apt handles signing keys has totally changed since the base image of this docker container was built, causing apt-update to fail, and hence container building to fail.

```
hcooper@rw:/containers/ropewiki/git/app$ docker run -it --network host mysql:5.7-debian bash
root@booty:/# apt update
[...]
Err:5 http://repo.mysql.com/apt/debian buster InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
[...]
Reading package lists... Done
W: GPG error: http://repo.mysql.com/apt/debian buster InRelease: The following signatures couldn't be verified
    because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
E: The repository 'http://repo.mysql.com/apt/debian buster InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

The fix is to use gpg to fetch and export the key to `/etc/apt/keyrings/`. Works fine now.

Another reason we should be upgrading the core software stack 😉 *cough* https://github.com/RopeWiki/app/pull/55 *cough*