### PR TITLE
Remove googleAnalytics extension & config

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -106,7 +106,6 @@ RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extens
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-UrlGetParameters UrlGetParameters && cd UrlGetParameters && git checkout 68afd03
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-Variables Variables && cd Variables && git checkout 6f4bbd0
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-PdfHandler PdfHandler && cd PdfHandler && git checkout 5e29202
-RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-googleAnalytics googleAnalytics && cd googleAnalytics && git checkout ce5ef02
 RUN cd /rw/extensions && git clone https://gitlab.com/nornagon/Preloader && cd Preloader && git checkout 02539e0
 RUN cd /rw/extensions && git clone https://github.com/RopeWiki/SemanticForms && cd SemanticForms && git checkout 9169c63
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-skins-Vector Vector && cd Vector && git checkout fad72e2

--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -265,15 +265,6 @@ $sfgRenameEditTabs = true;
 
 # ===================================================
 
-require_once "$IP/extensions/googleAnalytics/googleAnalytics.php";
-// Replace xxxxxxx-x with YOUR GoogleAnalytics UA number
-$wgGoogleAnalyticsAccount = "UA-51086630-1"; 
-// Optional Variables (both default to true)
-$wgGoogleAnalyticsIgnoreSysops = false;
-$wgGoogleAnalyticsIgnoreBots = false;
-// If you use AdSense as well and have linked your accounts, set this to true to enable tracking
-$wgGoogleAnalyticsAddASAC = false;
-
 #These failed to work and had to be set in Maps/Maps_Settings.php
 $egMapsCoordinateNotation = 'Maps_COORDS_FLOAT';
 $egMapsCoordinateDirectional = false;


### PR DESCRIPTION
Purging the google Analytics code & config.

It doesn't work with newer versions of mediawiki (I'm working on upgrades), is in accurate with cloudflare sat in front of it, is creepy (and illegal without opt-in in a number of places), and as far as I'm aware no one looks at.

bye bye.