### PR TITLE
Fix minior deployment related warnings

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,6 @@
 # in README.md.
 #   python3 deploy_tool.py <SITE_NAME> dc build
 
-version: '3.6'
-
 services:
 
   # The RopeWiki MySQL database; see instructions in README.md to build the image

--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -166,14 +166,14 @@ USER root
 COPY ./webserver/scripts/system_start.sh /root/system_start.sh
 
 # Set default parameters (that may be overwritten via environment variables)
-ENV WG_DB_SERVER ropewiki_db
-ENV WG_DB_USER ropewiki
-ENV WG_DB_PASSWORD ropewikidatabasepassword
-ENV WG_HOSTNAME localhost
-ENV WG_PROTOCOL http
-ENV WG_SECRET_KEY 04f44118ad1899762bc60ed90d778aa72f92e9dc0d298c8f327755e503ceb84a
-ENV WG_UPGRADE_KEY 1ce9e4e2a0a3bf63
-ENV RW_ROBOTS robots_dev.txt
+ENV WG_DB_SERVER=ropewiki_db
+ENV WG_DB_USER=ropewiki
+ENV WG_DB_PASSWORD=ropewikidatabasepassword
+ENV WG_HOSTNAME=localhost
+ENV WG_PROTOCOL=http
+ENV WG_SECRET_KEY=04f44118ad1899762bc60ed90d778aa72f92e9dc0d298c8f327755e503ceb84a
+ENV WG_UPGRADE_KEY=1ce9e4e2a0a3bf63
+ENV RW_ROBOTS=robots_dev.txt
 
 ARG codebaseversion=When this image was built with Docker, <pre>codebaseversion</pre> Docker arg was not specified.
 RUN echo "<html><body>${codebaseversion}</body></html>" > /rw/codebase_version.html


### PR DESCRIPTION
Fixes a bunch of stuff we're being warned about when running "dc build"....

 - docker compose "version" no longer needed and should be removed.
 - docker env should use "="
 - python datetime "now" utc warnings
 - python format parameters provides but not used
 
All tested locally.