### PR TITLE
MW & PHP version variables

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -y upgrade
 # Install nginx
 RUN apt-get install -y --no-install-recommends nginx
 
+ARG PHP_VERSION=5.6
 # Install php and associated packages
 # PHP compatibility: https://www.mediawiki.org/wiki/Compatibility#PHP
 # Don't start the php service after installation
@@ -27,15 +28,19 @@ RUN apt-get install -y --no-install-recommends software-properties-common && \
     apt-get update && \
     printf '#!/bin/sh\nexit 0' > /usr/sbin/policy-rc.d && \
     apt-get install -y --no-install-recommends \
-        php5.6 \
-        php5.6-apcu \
-        php5.6-fpm \
-        php5.6-cli \
-        php5.6-mysql \
-        php5.6-imagick \
-        php5.6-xml \
-        php5.6-mbstring \
+        php$PHP_VERSION \
+        php$PHP_VERSION-apcu \
+        php$PHP_VERSION-fpm \
+        php$PHP_VERSION-cli \
+        php$PHP_VERSION-mysql \
+        php$PHP_VERSION-imagick \
+        php$PHP_VERSION-xml \
+        php$PHP_VERSION-mbstring \
         php-pear
+
+# Make version agnostic paths
+RUN ln -s /etc/php/$PHP_VERSION /etc/php/current
+RUN ln -s /etc/init.d/php$PHP_VERSION-fpm /etc/init.d/php-fpm
 
 # Install the PEAR mail module and its deps.
 RUN pear install --alldeps mail
@@ -48,26 +53,24 @@ RUN apt-get install -y --no-install-recommends wget unzip git nano sed curl imag
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Bump file size upload limit
-RUN sed -i 's/^;\?upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php/5.6/fpm/php.ini
-RUN sed -i 's/^;\?post_max_size.*/post_max_size = 10M/' /etc/php/5.6/fpm/php.ini
+RUN sed -i 's/^;\?upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php/current/fpm/php.ini
+RUN sed -i 's/^;\?post_max_size.*/post_max_size = 10M/' /etc/php/current/fpm/php.ini
 
 # Optimize php-fpm configs
-RUN sed -i 's/^;\?emergency_restart_threshold.*/emergency_restart_threshold = 10/' /etc/php/5.6/fpm/php-fpm.conf
-RUN sed -i 's/^;\?emergency_restart_interval.*/emergency_restart_interval = 1m/' /etc/php/5.6/fpm/php-fpm.conf
-RUN sed -i 's/^;\?process_control_timeout.*/process_control_timeout = 10s/' /etc/php/5.6/fpm/php-fpm.conf
+RUN sed -i 's/^;\?emergency_restart_threshold.*/emergency_restart_threshold = 10/' /etc/php/current/fpm/php-fpm.conf
+RUN sed -i 's/^;\?emergency_restart_interval.*/emergency_restart_interval = 1m/' /etc/php/current/fpm/php-fpm.conf
+RUN sed -i 's/^;\?process_control_timeout.*/process_control_timeout = 10s/' /etc/php/current/fpm/php-fpm.conf
 
 # php-fpm pool settings
-COPY ./webserver/fpm-pool.conf /etc/php/5.6/fpm/pool.d/www.conf
+COPY ./webserver/fpm-pool.conf /etc/php/current/fpm/pool.d/www.conf
 
 
 # === Install MediaWiki ===
-
-# Retrieve MediaWiki installation package and follow installation instructions:
-# https://phabricator.wikimedia.org/source/mediawiki/browse/REL1_25/INSTALL
-RUN wget https://releases.wikimedia.org/mediawiki/1.24/mediawiki-1.24.1.tar.gz && \
-    tar xvzf mediawiki-1.24.1.tar.gz && \
-	mv mediawiki-1.24.1 /usr/share/nginx/html/ropewiki && \
-	rm mediawiki-1.24.1.tar.gz
+ARG MV_VERSION=1.24.1
+RUN wget https://releases.wikimedia.org/mediawiki/${MV_VERSION%.*}/mediawiki-$MV_VERSION.tar.gz && \
+    tar xvzf mediawiki-$MV_VERSION.tar.gz && \
+	mv mediawiki-$MV_VERSION /usr/share/nginx/html/ropewiki && \
+	rm mediawiki-$MV_VERSION.tar.gz
 
 # Configure quick symlink
 RUN ln -s /usr/share/nginx/html/ropewiki /rw

--- a/webserver/fpm-pool.conf
+++ b/webserver/fpm-pool.conf
@@ -4,7 +4,7 @@
 user = www-data
 group = www-data
 
-listen = /run/php/php5.6-fpm.sock
+listen = /run/php/php-fpm.sock
 
 
 listen.owner = www-data

--- a/webserver/nginx/sites-enabled/ropewiki.com
+++ b/webserver/nginx/sites-enabled/ropewiki.com
@@ -22,7 +22,7 @@ server {
     # pass the PHP scripts to FastCGI server
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/var/run/php/php5.6-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php-fpm.sock;
         fastcgi_index index.php;
         include fastcgi.conf;
     }

--- a/webserver/scripts/system_start.sh
+++ b/webserver/scripts/system_start.sh
@@ -16,12 +16,8 @@ sed -i "s/{{WG_UPGRADE_KEY}}/$WG_UPGRADE_KEY/g" SiteSpecificSettings.php
 # Configure robots.txt
 cp "robots/$RW_ROBOTS" robots.txt
 
-# Increase php-fpm workers
-fpm_pool_config="/etc/php/5.6/fpm/pool.d/www.conf"
-sed -i '/pm.max_children =/c\pm.max_children = 16' $fpm_pool_config
-
 # Enable php opcache
-php_ini="/etc/php/5.6/fpm/php.ini"
+php_ini="/etc/php/current/fpm/php.ini"
 sed -i '/opcache.enable=/c\opcache.enable=1' $php_ini
 sed -i '/opcache.enable_cli/c\opcache.enable_cli=1' $php_ini
 sed -i '/opcache.memory_consumption/c\opcache.memory_consumption=128' $php_ini
@@ -30,7 +26,7 @@ sed -i '/opcache.max_accelerated_files/c\opcache.max_accelerated_files=10000' $p
 sed -i '/opcache.fast_shutdown/c\opcache.fast_shutdown=1' $php_ini
 
 # Start up services
-service php5.6-fpm start
+service php-fpm start
 service nginx start
 service cron start
 service ssh start


### PR DESCRIPTION
To make future upgrades simpler this defines the Mediawiki & PHP versions as variables which are used throughout the Dockerfile.

It also makes version agnostic paths (e.g `/etc/php/current/...`) which means versions changes don't required changes elsewhere (e.g. nginx configs).

It also deletes redundant php-fpm config from `system_start.sh`, as that's handled by a dedicated `fpm-pool.conf` file.