### PR TITLE
[Deprecate luca server] Create a kml to gpx converter in php

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -46,7 +46,7 @@ RUN ln -s /etc/init.d/php$PHP_VERSION-fpm /etc/init.d/php-fpm
 RUN pear install --alldeps mail
 
 # Install various tools
-RUN apt-get install -y --no-install-recommends wget unzip git nano sed curl imagemagick less vim
+RUN apt-get install -y --no-install-recommends wget unzip git nano sed curl imagemagick less vim gpsbabel
 
 # Install composer
 # https://stackoverflow.com/a/51446468/651139

--- a/webserver/html/ropewiki/kml_to_gpx.php
+++ b/webserver/html/ropewiki/kml_to_gpx.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * KML to GPX Converter
+ * 
+ * This PHP script accepts a POST request with a `file_path` parameter pointing to a KML file.
+ * It validates that the file path starts with "/images" and sanitizes the input to prevent
+ * potential security issues. The script uses gpsbabel to convert the KML file to GPX format 
+ * and outputs the result directly as the HTTP response with appropriate headers for file download.
+ * 
+ * Requirements:
+ * - gpsbabel must be installed and accessible on the server.
+ * - PHP shell_exec() and passthru() functions must be enabled.
+ */
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405); // Method Not Allowed
+    echo json_encode(['error' => 'HTTP 405 - Method Not Allowed']);
+    exit;
+}
+
+$inputFile = isset($_POST['file_path']) ? realpath($_POST['file_path']) : '';
+
+// Check if file path is valid, sanitized, and starts with "/images"
+if (empty($inputFile) || strpos($inputFile, realpath('/images')) !== 0 || !file_exists($inputFile)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid or unauthorized file path']);
+    exit;
+}
+
+header('Content-Type: application/gpx+xml');
+header('Content-Disposition: attachment; filename="' . basename($inputFile, '.kml') . '.gpx"');
+
+$command = escapeshellcmd("gpsbabel -i kml -f $inputFile -o gpx -F -");
+passthru($command, $returnVar);
+
+if ($returnVar !== 0) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Conversion failed']);
+}


### PR DESCRIPTION
The luca server has become very unreliable. Let's stop using it for stuff we don't need to.

This setups a replace for the `/luca/rwr?gpx` endpoint which does kml -> gpx conversion.

A POST request is sent to `https://ropewiki.com/kml_to_gpx.php` with the file_path parameter, which is the local on disk path to the KML file. It responds with the converted data.

This branch is already active to the production site, so you can test directly again ropewiki.com

After this is committed I'll update links to the old path (mostly in common.js I think).


## Testing
```
~$ curl -X POST -d "file_path=/rw/images/d/d7/Estaron.kml" https://ropewiki.com/kml_to_gpx.php
<?xml version="1.0" encoding="UTF-8"?>
<gpx version="1.0" creator="GPSBabel - http://www.gpsbabel.org" xmlns="http://www.topografix.com/GPX/1/0">                                                            <time>2024-12-07T01:34:04.576Z</time>
  <bounds minlat="42.533661000" minlon="1.178552000" maxlat="42.541308000" maxlon="1.181942000"/>                                                                     <wpt lat="42.537722000" lon="1.178552000">
    <ele>0.000</ele>
    <name>Parking 1</name>
    <cmt>Parking 1</cmt>
    <desc>Parking 1</desc>
  </wpt>
  <wpt lat="42.536497000" lon="1.181921000">
    <ele>0.000</ele>
    <name>Parking 2</name>
    <cmt>Parking 2</cmt>
    <desc>Parking 2</desc>
  </wpt>
  [...]
  ```
  
Test the POST detection works (using POST requests helps avoid crawlers hitting it).
  
```
~$ curl https://ropewiki.com/kml_to_gpx.php
{"error":"HTTP 405 - Method Not Allowed"}
```

Test bad file name detection (including reading files outside of /images).
```
~$ curl -X POST -d "file_path=/wrong" https://ropewiki.com/kml_to_gpx.php
{"error":"Invalid or unauthorized file path"}
```