### PR TITLE
Fixes to kml_to_gpx.php - works with mediawiki now.

### DIFF
--- a/webserver/html/ropewiki/kml_to_gpx.php
+++ b/webserver/html/ropewiki/kml_to_gpx.php
@@ -2,35 +2,48 @@
 /**
  * KML to GPX Converter
  * 
- * This PHP script accepts a POST request with a `file_path` parameter pointing to a KML file.
- * It validates that the file path starts with "/images" and sanitizes the input to prevent
- * potential security issues. The script uses gpsbabel to convert the KML file to GPX format 
- * and outputs the result directly as the HTTP response with appropriate headers for file download.
+ * It takes a "url" parameter from the GET request. The url is converted
+ * into a local path and checked to ensure it exists and is in the expected location.
+ * It then converts the KML file to GPX format using the gpsbabel command line tool.
+ * The converted GPX file is returned as a downloadable response.
  * 
  * Requirements:
  * - gpsbabel must be installed and accessible on the server.
  * - PHP shell_exec() and passthru() functions must be enabled.
  */
 
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
     http_response_code(405); // Method Not Allowed
     echo json_encode(['error' => 'HTTP 405 - Method Not Allowed']);
     exit;
 }
 
-$inputFile = isset($_POST['file_path']) ? realpath($_POST['file_path']) : '';
-
-// Check if file path is valid, sanitized, and starts with "/images"
-if (empty($inputFile) || strpos($inputFile, realpath('/images')) !== 0 || !file_exists($inputFile)) {
+// Check if "url" parameter is provided in GET request
+if (empty($_GET['url'])) {
     http_response_code(400);
-    echo json_encode(['error' => 'Invalid or unauthorized file path']);
+    echo json_encode(['error' => 'URL parameter is required']);
+    exit;
+}
+
+// Because mediawiki is infuriating we have to pass in "url", but we
+// strip off the domain, and tweak it to match the real path on the server.
+// We never actually fetch the URL, we just use it to get the path.
+
+$parsedUrl = parse_url($_GET['url']);
+$path = $parsedUrl['path'];
+$realpath = realpath('/rw' . $path);
+
+// Check the path is fully resolved, exists, and is in the expected location.
+if ($realpath === false || strpos($realpath, '/usr/share/nginx/html/ropewiki/images/') !== 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Error checking file path '. $realpath]);
     exit;
 }
 
 header('Content-Type: application/gpx+xml');
-header('Content-Disposition: attachment; filename="' . basename($inputFile, '.kml') . '.gpx"');
+header('Content-Disposition: attachment; filename="' . basename($realpath, '.kml') . '.gpx"');
 
-$command = escapeshellcmd("gpsbabel -i kml -f $inputFile -o gpx -F -");
+$command = escapeshellcmd("/usr/bin/gpsbabel -i kml -f $realpath -o gpx -F -");
 passthru($command, $returnVar);
 
 if ($returnVar !== 0) {


### PR DESCRIPTION
Attempt 2 at making the gpx converter run on the webserver not the luca server.

The "download gpx" link in `Template:KMLDisplay` is already updated to point to this.

Tested locally and then switched branches in prod for easy testing for others:

Try clicking "download gpx" under the map on any canyon, should take you to:

https://ropewiki.com/kml_to_gpx.php?url=https://ropewiki.com/images/a/ab/Heaps_Canyon.kml