### PR TITLE
PHP 5.6 -> 7.1

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y upgrade
 # Install nginx
 RUN apt-get install -y --no-install-recommends nginx
 
-ARG PHP_VERSION=5.6
+ARG PHP_VERSION=7.1
 # Install php and associated packages
 # PHP compatibility: https://www.mediawiki.org/wiki/Compatibility#PHP
 # Don't start the php service after installation
@@ -67,7 +67,7 @@ COPY ./webserver/fpm-pool.conf /etc/php/current/fpm/pool.d/www.conf
 
 
 # === Install MediaWiki ===
-ARG MV_VERSION=1.27.1
+ARG MV_VERSION=1.27.7
 RUN wget https://releases.wikimedia.org/mediawiki/${MV_VERSION%.*}/mediawiki-$MV_VERSION.tar.gz && \
     tar xvzf mediawiki-$MV_VERSION.tar.gz && \
 	mv mediawiki-$MV_VERSION /usr/share/nginx/html/ropewiki && \

--- a/webserver/fpm-pool.conf
+++ b/webserver/fpm-pool.conf
@@ -1,6 +1,4 @@
 [www]
-
-
 user = www-data
 group = www-data
 
@@ -9,12 +7,6 @@ listen = /run/php/php-fpm.sock
 
 listen.owner = www-data
 listen.group = www-data
-
-#pm = dynamic
-pm.max_children = 16
-#pm.start_servers = 2
-#pm.min_spare_servers = 1
-#pm.max_spare_servers = 3
 
 pm = ondemand
 pm.max_children = 16


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #113
* __->__ #114

MW 1.27.1 -> 1.27.7
PHP 5.6 -> 7.1

Small upgrade of mediawiki LTS version in order to unlock larger PHP upgrade.