### PR TITLE
Fix map coords

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -136,6 +136,13 @@ RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extens
 # UserAdmin
 # xml2wiki-dr
 
+# The Maps extension needs to return coordinates in decimal, not DMS.
+# Ideally this would be set in LocalSettings.php, but for some unknown
+# reason it never applies when set there.
+RUN sed -i "s/\(.*\$GLOBALS\['egMapsCoordinateNotation'\] =\).*/\1 Maps_COORDS_FLOAT;  # Ropewiki override/" /rw/extensions/Maps/Maps_Settings.php
+RUN sed -i "s/\(.*\$GLOBALS\['egMapsCoordinateDirectional'\] =\).*/\1 false;  # Ropewiki override/" /rw/extensions/Maps/Maps_Settings.php
+
+
 # === Install SphinxSearch ===
 
 RUN apt-get install -y --no-install-recommends sphinxsearch

--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -265,9 +265,9 @@ $wgPageFormsRenameEditTabs = true;
 
 # ===================================================
 
-#These failed to work and had to be set in Maps/Maps_Settings.php
-$egMapsCoordinateNotation = 'Maps_COORDS_FLOAT';
-$egMapsCoordinateDirectional = false;
+# These are set in Maps/Maps_Settings.php at container build time
+#  $egMapsCoordinateNotation = 'Maps_COORDS_FLOAT';
+#  $egMapsCoordinateDirectional = false;
 
 # See discussion about using these: https://github.com/RopeWiki/app/pull/58
 # but regardless, set them to an empty string to just stop log spew.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118

Summary:



Looks like these settings were manually overwritten in the past, but not ported to docker, so got lost after an upgrade.

---
Test Plan:

After a container rebuilt expected config is in place:
```
root@ropewiki_webserver:/# grep -E '(egMapsCoordinateNotation|egMapsCoordinateDirectional)' /rw/extensions/Maps/Maps_Settings.php
        $GLOBALS['egMapsCoordinateNotation'] = Maps_COORDS_FLOAT;  # Ropewiki override
        $GLOBALS['egMapsCoordinateDirectional'] = false;  # Ropewiki override
```

---
### Before
![2025-04-01 17_24_48-Waterflow_ Dingford Creek](https://github.com/user-attachments/assets/88824ed0-9684-4159-92ce-9bbaec6b742c)
![2025-04-01 17_22_30-Dingford Creek](https://github.com/user-attachments/assets/768c9a02-71ca-4391-9df9-b0025387a389)
---
### After
![2025-04-01 17_24_18-Waterflow_ Dingford Creek](https://github.com/user-attachments/assets/5aba847c-efc9-48f8-9bbe-27505ab1573c)
![2025-04-01 17_23_24-Dingford Creek](https://github.com/user-attachments/assets/6ff470d5-4633-4f27-ad89-6849da9b57fa)

