### PR TITLE
endpoint for basic activity logging

### DIFF
--- a/reverse_proxy/services.conf
+++ b/reverse_proxy/services.conf
@@ -58,6 +58,15 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
+  # This is an utterly crude approach, but it allows javascript
+  # to ping an endpoint that'll simply be logged in the nginx access
+  # logs for later analysis. Initially designed to help understand map usage.
+  #  e.g. $.get(SITE_BASE_URL + "/rwlog?leaflet&" + currentUser + "&" + pageName);
+  # Longer term some kind of structured activity logging system would be nice.
+  location /rwlog {
+    return 204;
+  }
+
   # This line logs accesses to this service
   access_log /logs/nginx/access.log combined;
 }


### PR DESCRIPTION
Per the code comments - this lets stuff controlled by javascript leave a log message in the proxy access logs for later analysis.

First usage is to track where all our map tile usage is coming from.