### PR TITLE
Add Scrapy to user-agent blocklist

### DIFF
--- a/reverse_proxy/blockips.conf
+++ b/reverse_proxy/blockips.conf
@@ -33,6 +33,7 @@ map $http_user_agent $block_agent {
     ~*Brightbot     1;
     ~*PetalBot      1;
     ~*DataForSeoBot 1;
+    ~*Scrapy        1;
 }
 
 # vodafonedsl.it


### PR DESCRIPTION
Scrapy is a scraping tooling someone was using to hammer the site.

I've manually edited the production nginx config to enable this already, load has dropped and the requests are all logging HTTP 444.