### PR TITLE
SMW 2.5.8 -> 3.0.2

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -79,10 +79,10 @@ RUN ln -s /usr/share/nginx/html/ropewiki /rw
 # === Install extensions ===
 
 WORKDIR /rw
-RUN composer require --no-update mediawiki/semantic-media-wiki 2.5.8
+RUN composer require --no-update mediawiki/semantic-media-wiki 3.0.2
 RUN composer require --no-update mediawiki/header-footer 3.0.1
-RUN composer require --no-update mediawiki/semantic-maps 3.1.3
-RUN composer require --no-update mediawiki/semantic-result-formats 2.4.2
+RUN composer require --no-update mediawiki/maps 4.4.0
+RUN composer require --no-update mediawiki/semantic-result-formats 3.0.1
 RUN COMPOSER_ALLOW_SUPERUSER=yes composer install
 WORKDIR /
 
@@ -111,7 +111,7 @@ COPY ./webserver/html/ropewiki/extensions/SemanticMediaWiki/smw_button.png /rw/e
 # https://github.com/NVIDIA/nvidia-docker/issues/714#issuecomment-386244620
 
 RUN cd /rw/extensions && git clone https://github.com/SemanticMediaWiki/SemanticCompoundQueries.git && cd SemanticCompoundQueries && git checkout f5eed72
-RUN cd /rw/extensions && git clone https://github.com/SemanticMediaWiki/SemanticDrilldown SemanticDrilldown && cd SemanticDrilldown && git checkout a569de7
+RUN cd /rw/extensions && git clone https://github.com/SemanticMediaWiki/SemanticDrilldown SemanticDrilldown && cd SemanticDrilldown && git checkout 692537b
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-PageForms PageForms && cd PageForms && git checkout 4.2
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-SemanticRating SemanticRating && cd SemanticRating
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-CategoryTree CategoryTree && cd CategoryTree && git checkout 52c3eb7

--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -217,6 +217,9 @@ require_once "$IP/extensions/Variables/Variables.php";
 require_once "$IP/extensions/TreeToQuery/TreeToQuery.php";
 require_once "$IP/extensions/MyVariables/MyVariables.php";
 
+# Adds support for more output formats from SMW (e.g. "array" type).
+wfLoadExtension( 'SemanticResultFormats' );
+
 # Feature tools
 require_once "$IP/extensions/MultimediaViewer/MultimediaViewer.php";
 require_once "$IP/extensions/PdfHandler/PdfHandler.php";

--- a/webserver/html/ropewiki/extensions/SemanticMediaWiki/.smw.json
+++ b/webserver/html/ropewiki/extensions/SemanticMediaWiki/.smw.json
@@ -1,0 +1,6 @@
+{
+    "ropewiki": {
+        "populate.smw_hash_field_complete": true,
+        "upgrade_key": "8625c3658f9b1e6482a0c58b53b8650ace11534d"
+    }
+}


### PR DESCRIPTION
This is a significant upgrade. It's paired with matching `maps`, `semantic-results formats`, and `SemanticDrilldown` upgrades.

**General notes:**

 - The upgraded `semantic results format` is needed in order to provide the `array` type of result format used in many pages.
 - new `semantic results format` also needed slideshow query changed - already fixed in master.
 
 **Important note:**
 - The database schema upgrade process is *long*. The `rebuildData.php` process takes ~19hr on my 8 core dev machine. (Update: I don't think the site needs to be offline/read-only that long - WIP).
 
 - the `.smw.json` file needs to be place *after* the database upgrade, but it's stored in this commit because logically it needs to be paired with these versions.
 
 The plan is to do the upgrade offline using a copy of the database taken after the site is put into read-only mode.
 
 The clock is ticking on upgraded due the shutdown of composer v1: https://github.com/RopeWiki/app/issues/123