### PR TITLE
[docs] Replace architecture description with diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@ flowchart TD;
     classDef folder fill:#bbeeee
 
     subgraph app
-        ropewiki_db["ropewiki_db<br><small>Image: ropewiki/database"</small>]
+        ropewiki_db
         click ropewiki_db "https://github.com/RopeWiki/app/tree/master/database" "MySQL database with non-file site data"
 
-        ropewiki_webserver["ropewiki_webserver<br><small>Image: ropewiki/webserver"</small>]
+        ropewiki_webserver
         click ropewiki_webserver "https://github.com/RopeWiki/app/tree/master/webserver" "MediaWiki server and file-based site data/uploads"
 
-        ropewiki_reverse_proxy["ropewiki_reverse_proxy<br><small>Image: ropewiki/webserver"</small>]
+        ropewiki_reverse_proxy
         click ropewiki_reverse_proxy "https://github.com/RopeWiki/app/tree/master/reverse_proxy" "TLS termination and redirects"
 
-        ropewiki_backup_manager["ropewiki_backup_manager<br><small>Image:ropewiki/backup_manager</small>"]
+        ropewiki_backup_manager
         click ropewiki_backup_manager "https://github.com/RopeWiki/app/tree/master/backup_manager" "Exposes site data for backup"
 
-        ropewiki_mailserver["ropewiki_mailserver<br><small>Image:ropewiki/mailserver</small>"]
+        ropewiki_mailserver
         click ropewiki_mailserver "https://github.com/RopeWiki/app/tree/master/mailserver" "SMTP relay server to send email"
 
         ropewiki_database_storage@{shape:cyl}

--- a/README.md
+++ b/README.md
@@ -7,14 +7,75 @@ contain the database content nor the `images` folder content of the real site).
 
 ### Site architecture
 
-* The [MySQL database](database/README.md) stores all the non-file site data
-* The [webserver](webserver/README.md) runs MediaWiki with extensions, and also stores all the file-based site
-  data/uploads
-    * Exposes port 8080 for direct access to the webserver that bypasses the reverse proxy
-* The [reverse proxy](reverse_proxy/README.md) manages TLS termination and also redirects according to target site
-    * Exposes ports 80 & 443 as the external-facing webserver
-* The [backup manager](backup_manager/README.md) exposes site data for backup
-    * Exposes port 22001 for SSH access to [`backupreader`](backup_manager/pubkeys/README.md) users
+```mermaid
+flowchart TD;
+    classDef volume fill:#dddddd,stroke:#333,stroke-width:1px
+    classDef external fill:#eeeebb
+    classDef folder fill:#bbeeee
+
+    subgraph app
+        ropewiki_db["ropewiki_db<br><small>Image: ropewiki/database"</small>]
+        click ropewiki_db "database" "MySQL database with non-file site data"
+
+        ropewiki_webserver["ropewiki_webserver<br><small>Image: ropewiki/webserver"</small>]
+        click ropewiki_webserver "webserver" "MediaWiki server and file-based site data/uploads"
+
+        ropewiki_reverse_proxy["ropewiki_reverse_proxy<br><small>Image: ropewiki/webserver"</small>]
+        click ropewiki_reverse_proxy "reverse_proxy" "TLS termination and redirects"
+
+        ropewiki_backup_manager["ropewiki_backup_manager<br><small>Image:ropewiki/backup_manager</small>"]
+        click ropewiki_backup_manager "backup_manager" "Exposes site data for backup"
+
+        ropewiki_mailserver["ropewiki_mailserver<br><small>Image:ropewiki/mailserver</small>"]
+        click ropewiki_mailserver "mailserver" "SMTP relay server to send email"
+
+        ropewiki_database_storage@{shape:cyl}
+        class ropewiki_database_storage volume
+        ropewiki_proxy_certs@{shape:cyl}
+        class ropewiki_proxy_certs volume
+        ropewiki_proxy_logs@{shape:cyl}
+        class ropewiki_proxy_logs volume
+
+        images["/rw/mount/images"]@{shape:cyl}
+        class images folder
+        sqlbackup["/rw/mount/sqlbackup"]@{shape:cyl}
+        class sqlbackup folder
+    end
+
+    Internet["Public Internet"]
+    class Internet external
+    backupreader["<code>backupreader</code> users"]
+    class backupreader external
+    click backupreader "backup_manager/pubkeys"
+    GMail
+    class GMail external
+
+    luca_server["luca server"]
+    click luca_server "https://github.com/RopeWiki/RWServer"
+    class luca_server external
+
+    ropewiki_webserver -- MySQL 3306 --> ropewiki_db -- /var/lib/mysql --> ropewiki_database_storage
+    ropewiki_webserver -- /usr/share/nginx/html/ropewiki/images --> images
+    ropewiki_webserver -- SMTP 25 --> ropewiki_mailserver -- TLS SMTP 587 --> GMail
+    ropewiki_reverse_proxy -- HTTP 80 --> ropewiki_webserver
+    ropewiki_reverse_proxy -- HTTP 80 --> luca_server
+    Internet -- HTTP 8080 --> ropewiki_webserver
+    Internet -- HTTPS 443 --> ropewiki_reverse_proxy
+    Internet -- HTTP 80 --> ropewiki_reverse_proxy
+    backupreader -- SSH 22001 --> ropewiki_backup_manager -- MySQL 3306 --> ropewiki_db
+    ropewiki_backup_manager -- mysqldump --> sqlbackup --> ropewiki_backup_manager
+    images --> ropewiki_backup_manager
+    ropewiki_reverse_proxy -- /etc/letsencrypt --> ropewiki_proxy_certs
+    ropewiki_reverse_proxy -- /logs --> ropewiki_proxy_logs
+
+    subgraph Legend
+        Container["docker container"]
+        Volume["docker-managed volume"]
+        class Volume volume
+        Folder["Folder on host machine"]
+        class Folder folder
+    end
+```
 
 ## Site deployment
 
@@ -65,7 +126,7 @@ the `PATH` (`python3 --version` to verify). Ignore all `apt` commands and instea
 1. Create a shortcut to declare passwords: create `~/rw_passwords.sh` (or another location) with content like:
 ```shell
 #!/bin/bash
-# These are the manditory environment variables needed to start a copy of the site
+# These are the mandatory environment variables needed to start a copy of the site
 export WG_DB_PASSWORD=<The password for the `ropewiki` DB user>
 export RW_ROOT_DB_PASSWORD=<The password for the `root` DB user>
 export RW_SMTP_USERNAME=<The username for logging into the smtp relay>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ contain the database content nor the `images` folder content of the real site).
 
 ### Site architecture
 
+<!-- Note: it would be great to have `click` links be relative rather than absolute, but that isn't possible: https://github.com/orgs/community/discussions/46096 -->
 ```mermaid
 flowchart TD;
     classDef volume fill:#dddddd,stroke:#333,stroke-width:1px
@@ -15,19 +16,19 @@ flowchart TD;
 
     subgraph app
         ropewiki_db["ropewiki_db<br><small>Image: ropewiki/database"</small>]
-        click ropewiki_db "database" "MySQL database with non-file site data"
+        click ropewiki_db "https://github.com/RopeWiki/app/tree/master/database" "MySQL database with non-file site data"
 
         ropewiki_webserver["ropewiki_webserver<br><small>Image: ropewiki/webserver"</small>]
-        click ropewiki_webserver "webserver" "MediaWiki server and file-based site data/uploads"
+        click ropewiki_webserver "https://github.com/RopeWiki/app/tree/master/webserver" "MediaWiki server and file-based site data/uploads"
 
         ropewiki_reverse_proxy["ropewiki_reverse_proxy<br><small>Image: ropewiki/webserver"</small>]
-        click ropewiki_reverse_proxy "reverse_proxy" "TLS termination and redirects"
+        click ropewiki_reverse_proxy "https://github.com/RopeWiki/app/tree/master/reverse_proxy" "TLS termination and redirects"
 
         ropewiki_backup_manager["ropewiki_backup_manager<br><small>Image:ropewiki/backup_manager</small>"]
-        click ropewiki_backup_manager "backup_manager" "Exposes site data for backup"
+        click ropewiki_backup_manager "https://github.com/RopeWiki/app/tree/master/backup_manager" "Exposes site data for backup"
 
         ropewiki_mailserver["ropewiki_mailserver<br><small>Image:ropewiki/mailserver</small>"]
-        click ropewiki_mailserver "mailserver" "SMTP relay server to send email"
+        click ropewiki_mailserver "https://github.com/RopeWiki/app/tree/master/mailserver" "SMTP relay server to send email"
 
         ropewiki_database_storage@{shape:cyl}
         class ropewiki_database_storage volume
@@ -46,7 +47,7 @@ flowchart TD;
     class Internet external
     backupreader["<code>backupreader</code> users"]
     class backupreader external
-    click backupreader "backup_manager/pubkeys"
+    click backupreader "https://github.com/RopeWiki/app/tree/master/backup_manager/pubkeys"
     GMail
     class GMail external
 

--- a/backup_manager/README.md
+++ b/backup_manager/README.md
@@ -6,6 +6,10 @@ The RopeWiki backup manager automatically makes periodic backups, when enabled. 
 follow the form `all-backup-YYYY-MM-DD-HHMMSS.sql.gz` and are stored in /home/backupreader/backups/ according
 to [backup_mysql.sh](scripts/backup_mysql.sh).
 
+The `images` data (most of the file-based data uploaded to the site) can be found in
+/home/backupreader/images/ according to the mounted volume in the
+[docker-compose file](../docker-compose.yaml).
+
 ## Copying backups offsite
 
 The database container is accessible via SSH directly at port 22001. Connect to the container using SSH via this port

--- a/backup_manager/pubkeys/README.md
+++ b/backup_manager/pubkeys/README.md
@@ -1,4 +1,3 @@
 # Backup public keys
 
-Users holding the private key to any of the public keys in this folder will be allowed to SSH into the database and
-webserver containers as `backupreader` to copy backups off-site.
+Users holding the private key to any of the public keys in this folder will be allowed to SSH into the backup_manager container as `backupreader` to makes backups off-site.


### PR DESCRIPTION
For the duration of this PR, the diagram can be previewed [here](https://github.com/BenjaminPelletier/app/tree/arch-docs?tab=readme-ov-file#site-architecture).

A few other small fixes are made to other parts of the documentation, discovered while checking the behavior and correctness of the diagram.