### PR TITLE
[hotfix] - fix broken line wrapping

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -54,11 +54,11 @@ RUN apt-get install -y --no-install-recommends \
     imagemagick \
     less \
     nano \
-    patch
+    patch \
     sed \
     unzip \
     vim \
-    wget \
+    wget
 
 # Install composer
 # https://stackoverflow.com/a/51446468/651139


### PR DESCRIPTION
Arhg. This was correct, then I quickly decided to sort the list alphabetically, and docker build caching didn't trigger the issue.