### PR TITLE
add ghostscript

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -50,6 +50,7 @@ RUN pear install --alldeps mail
 RUN apt-get install -y --no-install-recommends \
     curl \
     git \
+    ghostscript \
     gpsbabel \
     imagemagick \
     less \


### PR DESCRIPTION
This is needed by PDFHandler, example: `[[File:Urumbilum_Canyon.pdf]]`

**Before**
```
Error creating thumbnail: /bin/bash: line 1: /usr/bin/gs: No such file or directory convert: no decode delegate for this image format `' @ error/constitute.c/ReadImage/581. convert: no images defined `/tmp/transform_353c5b110b90.jpg' @ error/convert.c/ConvertImageCommand/3234.
```
**After**
PDF appears inline:
![image](https://github.com/user-attachments/assets/9166be59-e7d4-441b-8d16-3ea394547fe2)
