### PR TITLE
$wgRestrictDisplayTitle = false

### DIFF
--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -126,6 +126,7 @@ $wgUseTidy=true;
 
 $wgCapitalLinks = true;
 $wgAllowDisplayTitle = true;
+$wgRestrictDisplayTitle = false;
 
 $wgShowExceptionDetails = true;
 $wgEmailConfirmToEdit = true;


### PR DESCRIPTION
This lets the `DISPLAYTITLE` magic word free rein to change the displayed page title (rather than just the text case currently).

Will use it on a few pages like Main Page to improve the welcome message.

![image](https://github.com/user-attachments/assets/d0faadfe-f7a7-430f-bc92-46d33e49888c)