### PR TITLE
enable InputBox

### DIFF
--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -235,6 +235,7 @@ $smwgNamespacesWithSemanticLinks[NS_VOTES] = true;
 $smwgNamespacesWithSemanticLinks[NS_EVENTS] = true;
 
 wfLoadExtension( 'PageForms' );
+wfLoadExtension( 'InputBox' );
 
 require_once "$IP/extensions/SemanticRating/SemanticRating.php";
 


### PR DESCRIPTION
Going to use this inbuilt extension to add more appealing search boxes to the site.

Manually enabled in production to confirm it works with live version (my dev environment is a version ahead).

https://ropewiki.com/Special:Version

![image](https://github.com/user-attachments/assets/852f333e-8e60-4940-b058-39e176764dc0)


Sneak peak of new design I'm working on (not finalized)....
![image](https://github.com/user-attachments/assets/a13187f3-7ea6-4473-95bc-24597d3b19b9)
