### PR TITLE
Setup tileserver for public land tiles

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -121,6 +121,17 @@ services:
       - INBOUND_TLS=no  # Don't require local clients to use TLS
       - ACCEPTED_NETWORKS=172.16.0.0/12  # Only accept connections from docker's internal network
 
+  ropewiki_tileserver:
+    image: maptiler/tileserver-gl:latest
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    user: root
+    volumes:
+      - /mnt/rwimages/tiles:/data
+    command: -c config.json
+    depends_on: []
+
 volumes:
   ropewiki_database_storage:
     name: ropewiki_database_storage

--- a/reverse_proxy/services.conf
+++ b/reverse_proxy/services.conf
@@ -76,3 +76,10 @@ server {
   listen 80;
   return 301 https://{{WG_HOSTNAME}}$request_uri;
 }
+
+server {
+  server_name tiles.{{WG_HOSTNAME}};
+  location / {
+    proxy_pass http://ropewiki_tileserver:8080;
+  }
+}


### PR DESCRIPTION
This stands up a map tile server on it's own domain name `tiles.ropewiki.com`. The purpose is for serving the public lands at risk of being sold map tiles.

The tiles them selves are in `/rw/mount/images/tiles`

It's already up and running on the production site.

The domain is fronted by cloudflare for extra caching.

Post about it: https://www.facebook.com/groups/ropewiki/posts/3960980320781946