### PR TITLE
session.gc_maxlifetime = 86400

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -77,8 +77,6 @@ RUN sed -i 's/^;\?emergency_restart_threshold.*/emergency_restart_threshold = 10
 RUN sed -i 's/^;\?emergency_restart_interval.*/emergency_restart_interval = 1m/' /etc/php/current/fpm/php-fpm.conf
 RUN sed -i 's/^;\?process_control_timeout.*/process_control_timeout = 10s/' /etc/php/current/fpm/php-fpm.conf
 
-
-
 # php-fpm pool settings
 COPY ./webserver/fpm-pool.conf /etc/php/current/fpm/pool.d/www.conf
 


### PR DESCRIPTION
Users have been complaining about frequently being logged out.

After much experimenting I think it comes down to this value.

The previous default was 24 minutes. I've not investigated further but I suspect a recent upgrade changed that default to something previously higher.

Tested running the sed command by hand.