### PR TITLE
bypass CVE warning to allow webserver to build

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -96,6 +96,8 @@ RUN composer require --no-update mediawiki/semantic-media-wiki 3.2.3
 RUN composer require --no-update mediawiki/header-footer 3.0.1
 RUN composer require --no-update mediawiki/maps 8.0.0
 RUN composer require --no-update mediawiki/semantic-result-formats 3.2
+# Bypass warning regarding CVE-2022-48614 affecting SMW. See https://github.com/RopeWiki/app/issues/159
+RUN COMPOSER_ALLOW_SUPERUSER=yes composer config --no-plugins audit.ignore "PKSA-t71x-qf1n-7xwy"
 RUN COMPOSER_ALLOW_SUPERUSER=yes composer install
 WORKDIR /
 


### PR DESCRIPTION
We still need the webserver to build despite it running an old & vulnerable version for SMW.

I think this is a new feature of the "compose" tool, as the CVE in question is a few years old now.

Tested on dev & prod.


```
[...]
 => CACHED [19/53] RUN ln -s /usr/share/nginx/html/ropewiki /rw                                                                                                                                                                                                   0.0s
 => CACHED [20/53] WORKDIR /rw                                                                                                                                                                                                                                    0.0s
 => CACHED [21/53] RUN composer require --no-update mediawiki/semantic-media-wiki 3.2.3                                                                                                                                                                           0.0s
 => CACHED [22/53] RUN composer require --no-update mediawiki/header-footer 3.0.1                                                                                                                                                                                 0.0s
 => CACHED [23/53] RUN composer require --no-update mediawiki/maps 8.0.0                                                                                                                                                                                          0.0s
 => CACHED [24/53] RUN composer require --no-update mediawiki/semantic-result-formats 3.2                                                                                                                                                                         0.0s
 => [25/53] RUN COMPOSER_ALLOW_SUPERUSER=yes composer config --no-plugins audit.ignore "PKSA-t71x-qf1n-7xwy"                                                                                                                                                      0.3s
 => [26/53] RUN COMPOSER_ALLOW_SUPERUSER=yes composer install                                                                                                                                                                                                    11.9s
 => [27/53] RUN cd /rw/extensions/SemanticResultFormats/formats/slideshow &&   sed -i 's/jquery.ui.slider/jquery.ui/' SRF_SlideShow.php resources/ext.srf.slideshow.js                                                                                            0.4s
 => [28/53] COPY ./webserver/html/ropewiki/extensions/SemanticMediaWiki/smw_button.png /rw/extensions/usr/share/nginx/html/ropewiki/vendor/mediawiki/semantic-media-wiki/res/images/smw_button.png                                                                0.0s
 => [29/53] RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-CheckUser CheckUser && cd CheckUser && git checkout REL1_35                                                                                                      5.1s
 => [30/53] RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-MagicNoCache MagicNoCache && cd MagicNoCache && git checkout REL1_35                                                                                             0.8s
 => [31/53] RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-MyVariables MyVariables && cd MyVariables && git checkout REL1_35                                           
 [...]