### PR TITLE
restarted searchd if it exits

### DIFF
--- a/webserver/scripts/system_start.sh
+++ b/webserver/scripts/system_start.sh
@@ -40,7 +40,8 @@ echo Sphinx indexer started -- can take up to a minute
 indexer --config /etc/sphinxsearch/sphinx.conf --all
 sleep 2
 echo Sphinx indexer finished -- starting service
-searchd --config /etc/sphinxsearch/sphinx.conf >> /var/log/sphinxsearch/sphinx-startup.log 2>&1
+# Restart searchd if it crashes: https://github.com/RopeWiki/app/issues/154
+nohup bash -c "while true; do searchd --nodetach --config /etc/sphinxsearch/sphinx.conf >> /var/log/sphinxsearch/sphinx-startup.log 2>&1; sleep 2; done" &
 
 echo RopeWiki webserver ready to go!
 


### PR DESCRIPTION
Per https://github.com/RopeWiki/app/issues/154

This change simply wraps searchd such that if it exits, it's restarted after a 2 second delay - while not blocking the container startup or loosing logs.

The major causes of crashes (just trying to search) has already been fixed, this new occurrence seems more of an edge-case for which this mitigation seems reasonable to keep the site functioning.


Tested in dev & prod...

```
# Tail the searchd logs in real time...
tail -f /var/log/sphinxsearch/searchd.log
```

```
# kill searchd and watch it get restarted
root@ropewiki_webserver:/# pkill searchd
[...]
[Wed Jan 14 21:38:32.368 2026] [1625] caught SIGTERM, shutting down
[Wed Jan 14 21:38:32.499 2026] [1625] shutdown complete
[Wed Jan 14 21:38:32.368 2026] [1625] caught SIGTERM, shutting down
[Wed Jan 14 21:38:32.499 2026] [1625] shutdown complete
[Wed Jan 14 21:38:32.368 2026] [1625] caught SIGTERM, shutting down
[Wed Jan 14 21:38:32.499 2026] [1625] shutdown complete
[Wed Jan 14 21:38:34.509 2026] [1642] listening on 127.0.0.1:9312
[Wed Jan 14 21:38:34.522 2026] [1642] binlog: replaying log /var/lib/sphinxsearch/data/binlog.001
[Wed Jan 14 21:38:34.522 2026] [1642] binlog: replay stats: 0 rows in 0 commits; 0 updates, 0 reconfigure; 0 indexes
[Wed Jan 14 21:38:34.522 2026] [1642] binlog: finished replaying /var/lib/sphinxsearch/data/binlog.001; 0.0 MB in 0.000 sec
[Wed Jan 14 21:38:34.522 2026] [1642] binlog: replaying log /var/lib/sphinxsearch/data/binlog.002
[Wed Jan 14 21:38:34.522 2026] [1642] binlog: replay stats: 0 rows in 0 commits; 0 updates, 0 reconfigure; 0 indexes
[Wed Jan 14 21:38:34.522 2026] [1642] binlog: finished replaying /var/lib/sphinxsearch/data/binlog.002; 0.0 MB in 0.000 sec
[Wed Jan 14 21:38:34.522 2026] [1642] binlog: replaying log /var/lib/sphinxsearch/data/binlog.002
[Wed Jan 14 21:38:34.522 2026] [1642] binlog: replay stats: 0 rows in 0 commits; 0 updates, 0 reconfigure; 0 indexes
[Wed Jan 14 21:38:34.522 2026] [1642] binlog: finished replaying /var/lib/sphinxsearch/data/binlog.002; 0.0 MB in 0.000 sec
[Wed Jan 14 21:38:34.522 2026] [1642] binlog: finished replaying total 3 in 0.000 sec
[Wed Jan 14 21:38:34.523 2026] [1642] accepting connections
[...]
```

