### PR TITLE
Upgrade PHP 7.4 -> 8.1

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y upgrade
 # Install nginx
 RUN apt-get install -y --no-install-recommends nginx
 
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.1
 # Install php and associated packages
 # PHP compatibility: https://www.mediawiki.org/wiki/Compatibility#PHP
 # Don't start the php service after installation
@@ -134,9 +134,7 @@ RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extens
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-UrlGetParameters UrlGetParameters && cd UrlGetParameters && git checkout $MW_REL_BRANCH
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-UserMerge UserMerge && cd UserMerge && git checkout $MW_REL_BRANCH
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-HeaderFooter HeaderFooter && cd HeaderFooter && git checkout $MW_REL_BRANCH
-
-# Last version to support PHP 7.x (fine to switch to master after PHP upgrade).
-RUN cd /rw/extensions && git clone https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo EmbedVideo && cd EmbedVideo && git checkout 6aa9058
+RUN cd /rw/extensions && git clone https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo EmbedVideo && cd EmbedVideo && git checkout $MW_REL_BRANCH
 
 # Used everywhere! Note: arrays & variables will break one day: https://phabricator.wikimedia.org/T250963
 RUN cd /rw/extensions && git clone https://github.com/wikimedia/mediawiki-extensions-Arrays Arrays && cd Arrays && git checkout $MW_REL_BRANCH
@@ -187,6 +185,11 @@ RUN cd /rw/extensions/Arrays && patch -l < ExtArrays.php.$MW_REL_BRANCH.patch
 # Apply PageForms patch - shouldn't be needed after MW 1.39
 # https://phabricator.wikimedia.org/T324728
 RUN cd /rw/extensions/PageForms && patch -l -p0 < PF_AutoEdit.php.$MW_REL_BRANCH.patch
+
+# Apply PageForms patches for PHP 8.1+ compatibility
+# (fixes str_replace() null parameter deprecation warnings)
+RUN cd /rw/extensions/PageForms && patch -l -p0 < PF_TemplateField.php.$MW_REL_BRANCH.patch
+RUN cd /rw/extensions/PageForms && patch -l -p0 < PF_FormPrinter.php.$MW_REL_BRANCH.patch
 
 # Sphinx: Setup cron job
 RUN apt-get install -y cron \

--- a/webserver/html/ropewiki/extensions/PageForms/PF_FormPrinter.php.REL1_39.patch
+++ b/webserver/html/ropewiki/extensions/PageForms/PF_FormPrinter.php.REL1_39.patch
@@ -1,0 +1,11 @@
+--- includes/PF_FormPrinter.php.orig	2026-03-07 15:33:12.000000000 -0800
++++ includes/PF_FormPrinter.php	2026-03-07 15:33:32.000000000 -0800
+@@ -1935,7 +1935,7 @@
+ 		// If doing a replace, the page text is actually the modified
+ 		// original page.
+ 		if ( !$is_embedded ) {
+-			$form_page_title = $parser->recursiveTagParse( str_replace( "{{!}}", "|", $form_page_title ) );
++			$form_page_title = $parser->recursiveTagParse( str_replace( "{{!}}", "|", $form_page_title ?? '' ) );  // PHP 8.1+ compatibility: handle null parameter
+ 		} else {
+ 			$form_page_title = null;
+ 		}

--- a/webserver/html/ropewiki/extensions/PageForms/PF_TemplateField.php.REL1_39.patch
+++ b/webserver/html/ropewiki/extensions/PageForms/PF_TemplateField.php.REL1_39.patch
@@ -1,0 +1,11 @@
+--- includes/PF_TemplateField.php.orig	2026-03-07 15:31:41.000000000 -0800
++++ includes/PF_TemplateField.php	2026-03-07 15:32:15.000000000 -0800
+@@ -183,7 +183,7 @@
+ 	 * @param string $semantic_property
+ 	 */
+ 	function setSemanticProperty( $semantic_property ) {
+-		$this->mSemanticProperty = str_replace( '\\', '', $semantic_property );
++		$this->mSemanticProperty = str_replace( '\\', '', $semantic_property ?? '' );  // PHP 8.1+ compatibility: handle null parameter
+ 		$this->mPossibleValues = [];
+ 		// set field type and possible values, if any
+ 		$this->setTypeAndPossibleValues();


### PR DESCRIPTION
A relatively minor upgrade, just need to handle some deprecation warnings.

This is the last PHP upgrade needed to unblock the final MW & SMW upgrades.