### PR TITLE
DEV_IMAGE_PROXY_MODE

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,6 +50,7 @@ services:
       - WG_DB_USER=${WG_DB_USERNAME:-ropewiki}
       - WG_DB_PASSWORD=${WG_DB_PASSWORD:-thispasswordonlyworksuntildbisrestored}
       - RW_ROBOTS=${RW_ROBOTS:-robots_dev.txt}
+      - DEV_IMAGE_PROXY_MODE=${DEV_IMAGE_PROXY_MODE:-false}
     depends_on:
       - ropewiki_db
     volumes:
@@ -73,6 +74,7 @@ services:
       - "443:443"
     environment:
       - WG_HOSTNAME=${WG_HOSTNAME:-localhost}
+      - DEV_IMAGE_PROXY_MODE=${DEV_IMAGE_PROXY_MODE:-false}
     depends_on:
       - ropewiki_webserver
     volumes:

--- a/reverse_proxy/scripts/system_start.sh
+++ b/reverse_proxy/scripts/system_start.sh
@@ -8,6 +8,20 @@ else
   echo "Configuring nginx services..."
   sed -i "s/{{WG_HOSTNAME}}/$WG_HOSTNAME/g" /etc/nginx/services.conf
 
+  # Configure image proxy mode if DEV_IMAGE_PROXY_MODE is set.
+  # https://github.com/RopeWiki/app/wiki/Image-Proxy-Mode
+  if [ -n "$DEV_IMAGE_PROXY_MODE" ]; then
+    echo "Configuring DEV_IMAGE_PROXY_MODE..."
+    sed -i '/server {/r /dev/stdin' /etc/nginx/services.conf <<'EOF'
+    location /images/ {
+        proxy_pass https://ropewiki.com/images/;
+        proxy_set_header Host ropewiki.com;
+        proxy_ssl_server_name on;
+        proxy_ssl_name ropewiki.com;
+    }
+EOF
+  fi
+
   mkdir -p /logs/goaccess/db
   mkdir -p /logs/nginx
   touch /logs/nginx/access.log

--- a/webserver/scripts/system_start.sh
+++ b/webserver/scripts/system_start.sh
@@ -13,6 +13,19 @@ sed -i "s/{{WG_PROTOCOL}}/$WG_PROTOCOL/g" SiteSpecificSettings.php
 sed -i "s/{{WG_SECRET_KEY}}/$WG_SECRET_KEY/g" SiteSpecificSettings.php
 sed -i "s/{{WG_UPGRADE_KEY}}/$WG_UPGRADE_KEY/g" SiteSpecificSettings.php
 
+# Configure image proxy mode if DEV_IMAGE_PROXY_MODE is set.
+# https://github.com/RopeWiki/app/wiki/Image-Proxy-Mode
+if [ -n "$DEV_IMAGE_PROXY_MODE" ]; then
+  echo "Configuring DEV_IMAGE_PROXY_MODE..."
+  cat >> LocalSettings.php <<'EOF'
+
+# Serve images from production
+$wgUploadPath = "https://ropewiki.com/images/";
+$wgThumbPath = "https://ropewiki.com/images/thumb";
+$wgGenerateThumbnailOnParse = false;
+EOF
+fi
+
 # Configure robots.txt
 cp "robots/$RW_ROBOTS" robots.txt
 


### PR DESCRIPTION
One of the main problems with creating development environments is the need for a complete copy of `images/` to be present locally.

I came up with this clever trick to avoid the need. Development instance can use images (and kmls/pdf/etc) directly from production.

The dev site will function as normal, albeit uploading images/kml will fail (but not often required in development).

I've been using this for the last week, and it's worked surprisingly well. Initially I tried complex POSIX to http fuse proxies, then stumbled onto this.

I documented it here: https://github.com/RopeWiki/app/wiki/Image-Proxy-Mode