### PR TITLE
Fix links to User: pages

### DIFF
--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -360,3 +360,12 @@ $wgMimeTypeExclusions = array_diff(
     $wgMimeTypeExclusions,
     [ 'application/xml', 'text/xml' ]
 );
+
+// Make links to User pages always appear as existing, even if not created yet.
+// MediaWiki:Hf-nsheader-User provides a user overview regardless if the page has been created.
+$wgHooks['TitleIsAlwaysKnown'][] = function ( $title, &$isKnown ) {
+	if ( $title->getNamespace() === NS_USER ) {
+		$isKnown = true;
+	}
+	return true;
+};


### PR DESCRIPTION
Small things I've meant to fix forever...

User: pages always have content regardless if they've been actually been "created" or not - thanks to the `MediaWiki:Hf-nsheader-User` template which adds stats & contact links to every User: page.

This PR fixes links to the User: pages, which would incorrectly send people to `/edit` if the page hadn't been customized yet.

**Link to non-customized User: page before:**
<img width="467" height="238" alt="2026-03-10 19_07_25-File_Middle Earth-28 jpg - ropewiki — Mozilla Firefox" src="https://github.com/user-attachments/assets/2f4acebb-3f30-410a-b432-e92bcc5def13" />

**Link to non-customized User: page After:**
<img width="356" height="194" alt="2026-03-10 19_06_57-File_Middle Earth-28 jpg - ropewiki — Mozilla Firefox" src="https://github.com/user-attachments/assets/2ae33df7-9b04-4ede-80ba-0079eceab014" />

**User: page:**
<img width="428" height="324" alt="2026-03-10 19_08_27-User_Dominik - ropewiki — Mozilla Firefox" src="https://github.com/user-attachments/assets/ddd36450-8f0b-4514-918a-1ec8e680d0d0" />