### PR TITLE
Fix mess of nginx/php/mediawiki upload size limits

### DIFF
--- a/reverse_proxy/nginx.conf
+++ b/reverse_proxy/nginx.conf
@@ -29,7 +29,8 @@ http {
     types_hash_max_size 2048;
     server_tokens off;
 
-    client_max_body_size 20m;
+    # See webserver/README.md to understand upload limits.
+    client_max_body_size 11M;
     client_body_timeout 60;
     client_body_buffer_size 128k;
 

--- a/webserver/README.md
+++ b/webserver/README.md
@@ -1,3 +1,27 @@
 # webserver
 
 This folder contains the resources necessary to build the RopeWiki webserver Docker image.
+
+
+## Upload limits
+There are 4 places which effect the upload limit, in order they are:
+ - reverse_proxy (nginx)
+ - webserver (nginx)
+ - php config
+ - mediawiki config
+
+### nginx
+Nginx will return a HTTP 413 error if `client_max_body_size` is exceed by an uploaded file.
+
+This is a "hard" error, and will likely give the user an ugly error page. Therefore it's
+important that this value is equal to or higher than the php/mediawiki value.
+
+Both the webserver & reverse_proxy need this value set. It's set at the global (http {...})
+level to avoid confusion around different paths getting different limits.
+
+### Mediawiki
+Mediawiki will pick whichever of these three is the lowest, and give a "soft" error before
+the upload begins:
+ - `upload_max_filesize` (php.ini)
+ - `post_max_size` (php.ini)
+ - `wgMaxUploadSize`, defaults to 100MB (LocalSettings.php)

--- a/webserver/html/ropewiki/LocalSettings.php
+++ b/webserver/html/ropewiki/LocalSettings.php
@@ -259,7 +259,7 @@ $wgPageFormsRenameEditTabs = true;
 
 # ===================================================
 
-# Upload limits are set in php.ini (upload_max_filesize)
+# See README.md to understand upload limits.
 #$wgUploadSizeWarning = 5242880;
 #$wgMaxUploadSize = 5242880;
 

--- a/webserver/nginx/nginx.conf
+++ b/webserver/nginx/nginx.conf
@@ -25,7 +25,8 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    client_max_body_size 20m;
+    # See webserver/README.md to understand upload limits.
+    client_max_body_size 11M;
     client_body_buffer_size 128k;
 
     access_log /var/log/nginx/access.log;

--- a/webserver/nginx/sites-enabled/ropewiki.com
+++ b/webserver/nginx/sites-enabled/ropewiki.com
@@ -3,8 +3,7 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server ipv6only=on;
-        #add_header Access-Control-Allow-Origin www.ropewiki.com;
-        client_max_body_size 5M;
+    #add_header Access-Control-Allow-Origin www.ropewiki.com;
     root /usr/share/nginx/html/ropewiki;
     index index.php index.html index.htm;
 


### PR DESCRIPTION
Unpicked the complex mess of upload size limits, and documented them.

tl;dr - 
 - 10MB is the upload limit (already set in php.ini), mediawiki should provide friendly errors.
 - both nginx configs will allow 11MB in order to not interfere in the process. It currently has contradictory settings.

This fixes the problem that mediawiki says the limit is 10M, but nginx will fail it if it's over 5M.

<img width="696" height="207" alt="image" src="https://github.com/user-attachments/assets/eca095d7-7c5d-4b7d-9b85-9e74ddcda2fe" />
