### PR TITLE
Fix rating popup JS errors

### DIFF
--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -195,6 +195,10 @@ RUN cd /rw/extensions/PageForms && patch -l -p0 < PF_FormPrinter.php.$MW_REL_BRA
 # (prevents auto-filled destination filename from being overwritten by uploaded file's name)
 RUN cd /rw/extensions/PageForms && patch -l -p0 < PF_upload.js.$MW_REL_BRANCH.patch
 
+# Apply PageForms patch to fix missing 'pf' dependency in rating module
+# (adds ext.pageforms dependency to ext.pageforms.rating module to prevent "pf is not defined" error)
+RUN cd /rw/extensions/PageForms && patch -l -p0 < extension.json.$MW_REL_BRANCH.patch
+
 # Sphinx: Setup cron job
 RUN apt-get install -y cron \
  && mv -f /rw/extensions/SphinxSearch/sphinx.cron /etc/cron.d/sphinxsearch-update \

--- a/webserver/html/ropewiki/extensions/PageForms/extension.json.REL1_39.patch
+++ b/webserver/html/ropewiki/extensions/PageForms/extension.json.REL1_39.patch
@@ -1,0 +1,12 @@
+--- extension.json	2026-04-21 14:30:13.653018861 -0700
++++ extension.json	2026-04-21 14:31:15.113484589 -0700
+@@ -339,6 +339,9 @@
+ 			"scripts": [
+ 				"libs/jquery.rateyo.js",
+ 				"libs/PF_rating.js"
++			],
++			"dependencies": [
++				"ext.pageforms"
+ 			]
+ 		},
+ 		"ext.pageforms.rating.styles": {


### PR DESCRIPTION
From user reports of rating system not working in the popup box: https://www.facebook.com/groups/1739720212907979/?multi_permalinks=4247116555501653

JS console log:
<img width="949" height="148" alt="image" src="https://github.com/user-attachments/assets/821fdf2a-6104-4462-b9af-69907c6e106f" />

This adds a missing extension dependency.

It's already fixed upstream in newer releases of Page Forms: https://github.com/wikimedia/mediawiki-extensions-PageForms/blob/master/extension.json#L420-L422

Before: 
<img width="618" height="359" alt="image" src="https://github.com/user-attachments/assets/2c005bb9-dc5d-4b5b-9246-5cce93bdf142" />

After:
<img width="580" height="367" alt="image" src="https://github.com/user-attachments/assets/1593ee9f-beb6-40b8-83b2-9619e25999df" />
